### PR TITLE
Show headers + body with colors in proxy output

### DIFF
--- a/Sources/Pry/BodyPrinter.swift
+++ b/Sources/Pry/BodyPrinter.swift
@@ -1,0 +1,111 @@
+import Foundation
+import NIOCore
+
+struct BodyPrinter {
+    static let maxBodyPreview = 2000
+
+    static func printRequestHead(_ head: HTTPRequestHead, host: String, port: Int) {
+        let method = "\(head.method)"
+        let url = head.uri
+        print(request(">>> \(method) \(url)") + " " + tunnel("-> \(host):\(port)"))
+
+        // Show key request headers
+        let interestingHeaders = ["Content-Type", "Authorization", "User-Agent", "Accept"]
+        for name in interestingHeaders {
+            if let value = head.headers[name].first {
+                print(colored("    \(name): \(value)", .dim))
+            }
+        }
+    }
+
+    static func printRequestBody(_ body: ByteBuffer?) {
+        guard let body = body, body.readableBytes > 0 else { return }
+        var buf = body
+        if let text = buf.readString(length: min(buf.readableBytes, maxBodyPreview)) {
+            let formatted = formatBody(text, contentType: nil)
+            print(colored("    Body: ", .dim) + formatted)
+        }
+    }
+
+    static func printResponseHead(_ head: HTTPResponseHead, host: String, https: Bool = false) {
+        let scheme = https ? "https" : "http"
+        let statusColor = head.status.code < 400
+            ? response("<<< \(head.status.code) \(head.status.reasonPhrase ?? "")")
+            : errText("<<< \(head.status.code) \(head.status.reasonPhrase ?? "")")
+        print("\(statusColor) " + tunnel("\(scheme)://\(host)"))
+
+        // Show key response headers
+        let interestingHeaders = ["Content-Type", "Content-Length", "Location", "Set-Cookie"]
+        for name in interestingHeaders {
+            if let value = head.headers[name].first {
+                print(colored("    \(name): \(value)", .dim))
+            }
+        }
+    }
+
+    static func printResponseBody(_ buffer: ByteBuffer, contentType: String?) {
+        var buf = buffer
+        guard buf.readableBytes > 0 else { return }
+        guard shouldPrintBody(contentType: contentType) else {
+            print(colored("    Body: [\(buf.readableBytes) bytes, \(contentType ?? "binary")]", .dim))
+            return
+        }
+        if let text = buf.readString(length: min(buf.readableBytes, maxBodyPreview)) {
+            let formatted = formatBody(text, contentType: contentType)
+            let truncated = buf.readableBytes > maxBodyPreview ? colored(" ...(truncated)", .dim) : ""
+            print(colored("    Body: ", .dim) + formatted + truncated)
+        }
+    }
+
+    static func printMock(path: String, json: String) {
+        print(mock("<<< MOCK \(path) (200 OK)"))
+        let formatted = formatBody(json, contentType: "application/json")
+        print(colored("    Body: ", .dim) + formatted)
+    }
+
+    private static func shouldPrintBody(contentType: String?) -> Bool {
+        guard let ct = contentType?.lowercased() else { return true }
+        if ct.contains("json") || ct.contains("text") || ct.contains("xml") || ct.contains("html") || ct.contains("javascript") {
+            return true
+        }
+        return false
+    }
+
+    private static func formatBody(_ text: String, contentType: String?) -> String {
+        // Try to pretty-print JSON
+        if let ct = contentType, ct.contains("json"), let data = text.data(using: .utf8) {
+            return prettyJSON(data) ?? text
+        }
+        // Auto-detect JSON even without content-type
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if (trimmed.hasPrefix("{") || trimmed.hasPrefix("[")), let data = text.data(using: .utf8) {
+            return prettyJSON(data) ?? text
+        }
+        // Truncate long non-JSON text
+        if text.count > 200 {
+            return String(text.prefix(200)) + "..."
+        }
+        return text
+    }
+
+    private static func prettyJSON(_ data: Data) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),
+              let str = String(data: pretty, encoding: .utf8) else {
+            return nil
+        }
+        // Indent each line for alignment
+        let lines = str.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > 1 {
+            return lines.enumerated().map { i, line in
+                i == 0 ? String(line) : "          \(line)"
+            }.joined(separator: "\n")
+        }
+        return str
+    }
+}
+
+// Re-export HTTPRequestHead for convenience
+import NIOHTTP1
+typealias HTTPRequestHead = NIOHTTP1.HTTPRequestHead
+typealias HTTPResponseHead = NIOHTTP1.HTTPResponseHead

--- a/Sources/Pry/Colors.swift
+++ b/Sources/Pry/Colors.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum Color: String {
+    case green = "\u{001B}[32m"
+    case blue = "\u{001B}[34m"
+    case cyan = "\u{001B}[36m"
+    case red = "\u{001B}[31m"
+    case yellow = "\u{001B}[33m"
+    case gray = "\u{001B}[90m"
+    case bold = "\u{001B}[1m"
+    case dim = "\u{001B}[2m"
+    case reset = "\u{001B}[0m"
+}
+
+func colored(_ text: String, _ color: Color) -> String {
+    "\(color.rawValue)\(text)\(Color.reset.rawValue)"
+}
+
+// Semantic helpers
+func request(_ text: String) -> String { colored(text, .green) }
+func response(_ text: String) -> String { colored(text, .cyan) }
+func mock(_ text: String) -> String { colored(text, .yellow) }
+func tunnel(_ text: String) -> String { colored(text, .gray) }
+func errText(_ text: String) -> String { colored(text, .red) }
+func info(_ text: String) -> String { colored(text, .blue) }
+func bold(_ text: String) -> String { colored(text, .bold) }

--- a/Sources/Pry/ConnectHandler.swift
+++ b/Sources/Pry/ConnectHandler.swift
@@ -127,7 +127,7 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
     }
 
     private func connectFailed(error: Error, context: ChannelHandlerContext) {
-        print("!!! CONNECT failed: \(error)")
+        print(errText("!!! CONNECT failed: \(error)"))
         state = .upgradeFailed
         let headers = HTTPHeaders([("Content-Length", "0"), ("Connection", "close")])
         let head = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .badGateway, headers: headers)
@@ -155,7 +155,7 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
     }
 
     private func setupTunnel(peerChannel: Channel, context: ChannelHandlerContext) {
-        print("--- TUNNEL \(connectHost) (passthrough)")
+        print(tunnel("--- TUNNEL \(connectHost) (passthrough)"))
         Config.appendLog("TUNNEL \(connectHost)")
 
         let (localGlue, peerGlue) = GlueHandler.matchedPair()
@@ -169,7 +169,7 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
             // Remove self last — this forwards any pending bytes via removeHandler()
             context.pipeline.syncOperations.removeHandler(self, promise: nil)
         } catch {
-            print("!!! Tunnel setup failed for \(connectHost): \(error)")
+            print(errText("!!! Tunnel setup failed for \(connectHost): \(error)"))
             peerChannel.close(mode: .all, promise: nil)
             context.close(promise: nil)
         }
@@ -183,7 +183,7 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
             return
         }
 
-        print(">>> INTERCEPT \(host)")
+        print(info(">>> INTERCEPT \(host)"))
         Config.appendLog("INTERCEPT \(host)")
 
         // Close raw remote channel — we'll make a TLS one later
@@ -211,11 +211,11 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
             }.flatMap {
                 context.pipeline.removeHandler(self)
             }.whenFailure { error in
-                print("!!! TLS setup failed for \(host): \(error)")
+                print(errText("!!! TLS setup failed for \(host): \(error)"))
                 context.close(promise: nil)
             }
         } catch {
-            print("!!! Cert generation failed for \(host): \(error)")
+            print(errText("!!! Cert generation failed for \(host): \(error)"))
             context.close(promise: nil)
         }
     }
@@ -279,7 +279,8 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private func handleDecryptedRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?) {
         let logEntry = "\(head.method) https://\(host)\(head.uri)"
-        print(">>> \(logEntry)")
+        BodyPrinter.printRequestHead(head, host: host, port: port)
+        BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
         // Check mocks — supports both "domain:path" and simple "/path" formats
@@ -295,7 +296,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                 matches = head.uri.hasPrefix(mockKey)
             }
             if matches {
-                print("<<< MOCK \(head.uri) (200 OK)")
+                BodyPrinter.printMock(path: head.uri, json: response)
                 Config.appendLog("MOCK \(head.uri) -> 200 OK")
                 var headers = HTTPHeaders()
                 headers.add(name: "Content-Type", value: "application/json")
@@ -336,12 +337,12 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                         }
                         remoteChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
                     case .failure(let error):
-                        print("!!! TLS forward failed to \(self.host): \(error)")
+                        print(errText("!!! TLS forward failed to \(self.host): \(error)"))
                         context.close(promise: nil)
                     }
                 }
         } catch {
-            print("!!! TLS context failed: \(error)")
+            print(errText("!!! TLS context failed: \(error)"))
             context.close(promise: nil)
         }
     }
@@ -358,17 +359,26 @@ final class TLSResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
         self.host = host
     }
 
+    private var contentType: String?
+    private var responseBody: ByteBuffer?
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let part = unwrapInboundIn(data)
         switch part {
         case .head(let head):
-            print("<<< \(head.status.code) https://\(host)")
+            BodyPrinter.printResponseHead(head, host: host, https: true)
             Config.appendLog("RESPONSE https://\(host) -> \(head.status.code)")
-            let serverHead = HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
+            contentType = head.headers["Content-Type"].first
+            responseBody = context.channel.allocator.buffer(capacity: 0)
+            let serverHead = NIOHTTP1.HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
             clientChannel.write(NIOAny(HTTPServerResponsePart.head(serverHead)), promise: nil)
-        case .body(let buffer):
+        case .body(var buffer):
+            responseBody?.writeBuffer(&buffer)
             clientChannel.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
         case .end(let trailers):
+            if let body = responseBody {
+                BodyPrinter.printResponseBody(body, contentType: contentType)
+            }
             clientChannel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(trailers))).whenComplete { _ in
                 self.clientChannel.close(promise: nil)
             }
@@ -377,7 +387,7 @@ final class TLSResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        print("!!! TLS response error from \(host): \(error)")
+        print(errText("!!! TLS response error from \(host): \(error)"))
         clientChannel.close(promise: nil)
         context.close(promise: nil)
     }

--- a/Sources/Pry/HTTPInterceptor.swift
+++ b/Sources/Pry/HTTPInterceptor.swift
@@ -44,7 +44,8 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
 
         // Log
         let logEntry = "\(head.method) \(head.uri) -> \(host):\(port)"
-        print(">>> \(logEntry)")
+        BodyPrinter.printRequestHead(head, host: host, port: port)
+        BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
         // Mock check
@@ -79,7 +80,7 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
     }
 
     private func respondWithMock(context: ChannelHandlerContext, json: String, path: String) {
-        print("<<< MOCK \(path) (200 OK)")
+        BodyPrinter.printMock(path: path, json: json)
         Config.appendLog("MOCK \(path) -> 200 OK")
 
         var headers = HTTPHeaders()
@@ -125,7 +126,7 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
                     remoteChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
 
                 case .failure(let error):
-                    print("!!! Connection failed to \(host):\(port) - \(error)")
+                    print(errText("!!! Connection failed to \(host):\(port) - \(error)"))
                     Config.appendLog("ERROR \(host):\(port) - \(error)")
                     clientChannel.close(promise: nil)
                 }
@@ -157,6 +158,8 @@ final class ResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private let clientChannel: Channel
     private let host: String
+    private var contentType: String?
+    private var responseBody: ByteBuffer?
 
     init(clientChannel: Channel, host: String) {
         self.clientChannel = clientChannel
@@ -168,15 +171,21 @@ final class ResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
 
         switch part {
         case .head(let head):
-            print("<<< \(head.status.code) \(host)")
+            BodyPrinter.printResponseHead(head, host: host)
             Config.appendLog("RESPONSE \(host) -> \(head.status.code)")
-            let serverHead = HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
+            contentType = head.headers["Content-Type"].first
+            responseBody = context.channel.allocator.buffer(capacity: 0)
+            let serverHead = NIOHTTP1.HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
             clientChannel.write(NIOAny(HTTPServerResponsePart.head(serverHead)), promise: nil)
 
-        case .body(let buffer):
+        case .body(var buffer):
+            responseBody?.writeBuffer(&buffer)
             clientChannel.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
 
         case .end(let trailers):
+            if let body = responseBody {
+                BodyPrinter.printResponseBody(body, contentType: contentType)
+            }
             clientChannel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(trailers))).whenComplete { _ in
                 self.clientChannel.close(promise: nil)
             }
@@ -185,7 +194,7 @@ final class ResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        print("!!! Response error from \(host): \(error)")
+        print(errText("!!! Response error from \(host): \(error)"))
         clientChannel.close(promise: nil)
         context.close(promise: nil)
     }


### PR DESCRIPTION
## Summary
Full traffic visibility:
- Request: method, URL, key headers (Content-Type, Authorization, User-Agent, Accept)
- Request body: auto-detect JSON, pretty print with indentation
- Response: colored status (green 2xx/3xx, red 4xx/5xx), key headers (Content-Type, Content-Length, Location, Set-Cookie)
- Response body: pretty-printed JSON, binary types show size only
- Mock responses: yellow with formatted JSON body
- All output truncated at 2000 chars for large responses

Includes Colors.swift (ANSI colors for terminal) and BodyPrinter.swift (formatting logic).

## Test plan
- [ ] `pry start` + `curl http://httpbin.org/get` shows JSON body pretty-printed
- [ ] `pry mock /api/test '{...}'` + curl shows yellow mock with body
- [ ] Binary responses show size instead of raw bytes
- [ ] Large responses are truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)