### PR TITLE
App icons from User-Agent + headers + body + colors

### DIFF
--- a/Sources/Pry/AppIdentifier.swift
+++ b/Sources/Pry/AppIdentifier.swift
@@ -1,0 +1,101 @@
+import Foundation
+import NIOHTTP1
+
+struct AppIdentifier {
+    struct AppInfo {
+        let icon: String
+        let name: String
+        let version: String?
+    }
+
+    static func identify(from headers: HTTPHeaders) -> AppInfo {
+        guard let ua = headers["User-Agent"].first else {
+            return AppInfo(icon: "❓", name: "Unknown", version: nil)
+        }
+        return parse(userAgent: ua)
+    }
+
+    static func parse(userAgent ua: String) -> AppInfo {
+        // Safari on iOS
+        if ua.contains("Safari/") && ua.contains("Mobile/") && ua.contains("iPhone") {
+            let version = extractVersion(from: ua, after: "Version/")
+            return AppInfo(icon: "🧭", name: "Safari", version: version)
+        }
+
+        // Safari on Mac
+        if ua.contains("Safari/") && ua.contains("Macintosh") {
+            let version = extractVersion(from: ua, after: "Version/")
+            return AppInfo(icon: "🧭", name: "Safari macOS", version: version)
+        }
+
+        // Chrome
+        if ua.contains("Chrome/") {
+            let version = extractVersion(from: ua, after: "Chrome/")
+            return AppInfo(icon: "🌐", name: "Chrome", version: version)
+        }
+
+        // Firefox
+        if ua.contains("Firefox/") {
+            let version = extractVersion(from: ua, after: "Firefox/")
+            return AppInfo(icon: "🦊", name: "Firefox", version: version)
+        }
+
+        // curl
+        if ua.hasPrefix("curl/") {
+            let version = extractVersion(from: ua, after: "curl/")
+            return AppInfo(icon: "🖥️", name: "curl", version: version)
+        }
+
+        // Python requests
+        if ua.hasPrefix("python-requests/") {
+            let version = extractVersion(from: ua, after: "python-requests/")
+            return AppInfo(icon: "🐍", name: "Python", version: version)
+        }
+
+        // Xcode
+        if ua.contains("Xcode") {
+            return AppInfo(icon: "🔨", name: "Xcode", version: nil)
+        }
+
+        // iOS app with CFNetwork (AppName/Version CFNetwork/X Darwin/Y)
+        if ua.contains("CFNetwork/") {
+            let parts = ua.split(separator: " ")
+            if let first = parts.first, first.contains("/") {
+                let appParts = first.split(separator: "/")
+                let name = String(appParts[0])
+                let version = appParts.count > 1 ? String(appParts[1]) : nil
+                return AppInfo(icon: "📱", name: name, version: version)
+            }
+            return AppInfo(icon: "📱", name: "iOS App", version: nil)
+        }
+
+        // WKWebView (has Mobile/ but not Safari/)
+        if ua.contains("Mobile/") && !ua.contains("Safari/") {
+            return AppInfo(icon: "📱", name: "WebView", version: nil)
+        }
+
+        // Generic with AppName/Version pattern
+        let parts = ua.split(separator: " ")
+        if let first = parts.first, first.contains("/") {
+            let appParts = first.split(separator: "/")
+            let name = String(appParts[0])
+            let version = appParts.count > 1 ? String(appParts[1]) : nil
+            return AppInfo(icon: "🔧", name: name, version: version)
+        }
+
+        return AppInfo(icon: "❓", name: String(ua.prefix(20)), version: nil)
+    }
+
+    static func label(from headers: HTTPHeaders) -> String {
+        let app = identify(from: headers)
+        let ver = app.version.map { "/\($0)" } ?? ""
+        return "\(app.icon) \(app.name)\(ver)"
+    }
+
+    private static func extractVersion(from ua: String, after prefix: String) -> String? {
+        guard let range = ua.range(of: prefix) else { return nil }
+        let rest = ua[range.upperBound...]
+        let version = rest.prefix(while: { $0 != " " && $0 != ")" && $0 != ";" })
+        return version.isEmpty ? nil : String(version)
+    }
+}

--- a/Sources/Pry/BodyPrinter.swift
+++ b/Sources/Pry/BodyPrinter.swift
@@ -1,0 +1,112 @@
+import Foundation
+import NIOCore
+
+struct BodyPrinter {
+    static let maxBodyPreview = 2000
+
+    static func printRequestHead(_ head: HTTPRequestHead, host: String, port: Int) {
+        let method = "\(head.method)"
+        let url = head.uri
+        let appLabel = AppIdentifier.label(from: head.headers)
+        print(colored(appLabel, .bold) + " " + request(">>> \(method) \(url)") + " " + tunnel("-> \(host):\(port)"))
+
+        // Show key request headers (skip User-Agent since it's in the app label)
+        let interestingHeaders = ["Content-Type", "Authorization", "Accept"]
+        for name in interestingHeaders {
+            if let value = head.headers[name].first {
+                print(colored("    \(name): \(value)", .dim))
+            }
+        }
+    }
+
+    static func printRequestBody(_ body: ByteBuffer?) {
+        guard let body = body, body.readableBytes > 0 else { return }
+        var buf = body
+        if let text = buf.readString(length: min(buf.readableBytes, maxBodyPreview)) {
+            let formatted = formatBody(text, contentType: nil)
+            print(colored("    Body: ", .dim) + formatted)
+        }
+    }
+
+    static func printResponseHead(_ head: HTTPResponseHead, host: String, https: Bool = false) {
+        let scheme = https ? "https" : "http"
+        let statusColor = head.status.code < 400
+            ? response("<<< \(head.status.code) \(head.status.reasonPhrase ?? "")")
+            : errText("<<< \(head.status.code) \(head.status.reasonPhrase ?? "")")
+        print("\(statusColor) " + tunnel("\(scheme)://\(host)"))
+
+        // Show key response headers
+        let interestingHeaders = ["Content-Type", "Content-Length", "Location", "Set-Cookie"]
+        for name in interestingHeaders {
+            if let value = head.headers[name].first {
+                print(colored("    \(name): \(value)", .dim))
+            }
+        }
+    }
+
+    static func printResponseBody(_ buffer: ByteBuffer, contentType: String?) {
+        var buf = buffer
+        guard buf.readableBytes > 0 else { return }
+        guard shouldPrintBody(contentType: contentType) else {
+            print(colored("    Body: [\(buf.readableBytes) bytes, \(contentType ?? "binary")]", .dim))
+            return
+        }
+        if let text = buf.readString(length: min(buf.readableBytes, maxBodyPreview)) {
+            let formatted = formatBody(text, contentType: contentType)
+            let truncated = buf.readableBytes > maxBodyPreview ? colored(" ...(truncated)", .dim) : ""
+            print(colored("    Body: ", .dim) + formatted + truncated)
+        }
+    }
+
+    static func printMock(path: String, json: String) {
+        print(mock("<<< MOCK \(path) (200 OK)"))
+        let formatted = formatBody(json, contentType: "application/json")
+        print(colored("    Body: ", .dim) + formatted)
+    }
+
+    private static func shouldPrintBody(contentType: String?) -> Bool {
+        guard let ct = contentType?.lowercased() else { return true }
+        if ct.contains("json") || ct.contains("text") || ct.contains("xml") || ct.contains("html") || ct.contains("javascript") {
+            return true
+        }
+        return false
+    }
+
+    private static func formatBody(_ text: String, contentType: String?) -> String {
+        // Try to pretty-print JSON
+        if let ct = contentType, ct.contains("json"), let data = text.data(using: .utf8) {
+            return prettyJSON(data) ?? text
+        }
+        // Auto-detect JSON even without content-type
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if (trimmed.hasPrefix("{") || trimmed.hasPrefix("[")), let data = text.data(using: .utf8) {
+            return prettyJSON(data) ?? text
+        }
+        // Truncate long non-JSON text
+        if text.count > 200 {
+            return String(text.prefix(200)) + "..."
+        }
+        return text
+    }
+
+    private static func prettyJSON(_ data: Data) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),
+              let str = String(data: pretty, encoding: .utf8) else {
+            return nil
+        }
+        // Indent each line for alignment
+        let lines = str.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > 1 {
+            return lines.enumerated().map { i, line in
+                i == 0 ? String(line) : "          \(line)"
+            }.joined(separator: "\n")
+        }
+        return str
+    }
+}
+
+// Re-export HTTPRequestHead for convenience
+import NIOHTTP1
+typealias HTTPRequestHead = NIOHTTP1.HTTPRequestHead
+typealias HTTPResponseHead = NIOHTTP1.HTTPResponseHead

--- a/Sources/Pry/ConnectHandler.swift
+++ b/Sources/Pry/ConnectHandler.swift
@@ -279,7 +279,8 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private func handleDecryptedRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?) {
         let logEntry = "\(head.method) https://\(host)\(head.uri)"
-        print(request(">>> \(logEntry)"))
+        BodyPrinter.printRequestHead(head, host: host, port: port)
+        BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
         // Check mocks — supports both "domain:path" and simple "/path" formats
@@ -295,7 +296,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                 matches = head.uri.hasPrefix(mockKey)
             }
             if matches {
-                print(mock("<<< MOCK \(head.uri) (200 OK)"))
+                BodyPrinter.printMock(path: head.uri, json: response)
                 Config.appendLog("MOCK \(head.uri) -> 200 OK")
                 var headers = HTTPHeaders()
                 headers.add(name: "Content-Type", value: "application/json")
@@ -352,6 +353,8 @@ final class TLSResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private let clientChannel: Channel
     private let host: String
+    private var contentType: String?
+    private var responseBody: ByteBuffer?
 
     init(clientChannel: Channel, host: String) {
         self.clientChannel = clientChannel
@@ -362,14 +365,19 @@ final class TLSResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
         let part = unwrapInboundIn(data)
         switch part {
         case .head(let head):
-            let statusColor = head.status.code < 400 ? response("<<< \(head.status.code)") : errText("<<< \(head.status.code)")
-            print("\(statusColor) https://\(host)")
+            BodyPrinter.printResponseHead(head, host: host, https: true)
             Config.appendLog("RESPONSE https://\(host) -> \(head.status.code)")
-            let serverHead = HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
+            contentType = head.headers["Content-Type"].first
+            responseBody = context.channel.allocator.buffer(capacity: 0)
+            let serverHead = NIOHTTP1.HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
             clientChannel.write(NIOAny(HTTPServerResponsePart.head(serverHead)), promise: nil)
-        case .body(let buffer):
+        case .body(var buffer):
+            responseBody?.writeBuffer(&buffer)
             clientChannel.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
         case .end(let trailers):
+            if let body = responseBody {
+                BodyPrinter.printResponseBody(body, contentType: contentType)
+            }
             clientChannel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(trailers))).whenComplete { _ in
                 self.clientChannel.close(promise: nil)
             }

--- a/Sources/Pry/HTTPInterceptor.swift
+++ b/Sources/Pry/HTTPInterceptor.swift
@@ -44,7 +44,8 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
 
         // Log
         let logEntry = "\(head.method) \(head.uri) -> \(host):\(port)"
-        print(request(">>> \(head.method) \(head.uri)") + " " + tunnel("-> \(host):\(port)"))
+        BodyPrinter.printRequestHead(head, host: host, port: port)
+        BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
         // Mock check
@@ -79,7 +80,7 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
     }
 
     private func respondWithMock(context: ChannelHandlerContext, json: String, path: String) {
-        print(mock("<<< MOCK \(path) (200 OK)"))
+        BodyPrinter.printMock(path: path, json: json)
         Config.appendLog("MOCK \(path) -> 200 OK")
 
         var headers = HTTPHeaders()
@@ -157,6 +158,8 @@ final class ResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private let clientChannel: Channel
     private let host: String
+    private var contentType: String?
+    private var responseBody: ByteBuffer?
 
     init(clientChannel: Channel, host: String) {
         self.clientChannel = clientChannel
@@ -168,16 +171,21 @@ final class ResponseForwarder: ChannelInboundHandler, @unchecked Sendable {
 
         switch part {
         case .head(let head):
-            let statusColor = head.status.code < 400 ? response("<<< \(head.status.code)") : errText("<<< \(head.status.code)")
-            print("\(statusColor) \(host)")
+            BodyPrinter.printResponseHead(head, host: host)
             Config.appendLog("RESPONSE \(host) -> \(head.status.code)")
-            let serverHead = HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
+            contentType = head.headers["Content-Type"].first
+            responseBody = context.channel.allocator.buffer(capacity: 0)
+            let serverHead = NIOHTTP1.HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
             clientChannel.write(NIOAny(HTTPServerResponsePart.head(serverHead)), promise: nil)
 
-        case .body(let buffer):
+        case .body(var buffer):
+            responseBody?.writeBuffer(&buffer)
             clientChannel.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
 
         case .end(let trailers):
+            if let body = responseBody {
+                BodyPrinter.printResponseBody(body, contentType: contentType)
+            }
             clientChannel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(trailers))).whenComplete { _ in
                 self.clientChannel.close(promise: nil)
             }


### PR DESCRIPTION
## Summary
This PR combines all display improvements:

**App identification from User-Agent:**
- 🧭 Safari | 🌐 Chrome | 🦊 Firefox | 🖥️ curl | 🐍 Python | 🔨 Xcode | 📱 iOS apps | 🔧 Generic
- Format: `📱 MyApp/1.0 >>> GET /api/users -> host:80`

**Headers + body display:**
- Request: key headers (Content-Type, Authorization, Accept)
- Response: key headers (Content-Type, Content-Length, Location, Set-Cookie)
- Body: pretty-printed JSON, binary shows size only, truncated at 2000 chars

**Colors:**
- Green: requests | Cyan: responses | Red: errors | Yellow: mocks | Gray: tunnels | Blue: intercept

Subsumes PRs #8 and #9.

## Test plan
- [ ] `curl -x localhost:8080` shows 🖥️ curl icon
- [ ] iOS Simulator app shows 📱 AppName
- [ ] Safari shows 🧭 Safari
- [ ] JSON responses pretty-printed
- [ ] Colors visible in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)