### PR TITLE
TUI visual polish: dark theme with GitHub color palette

### DIFF
--- a/Sources/Pry/TUI/ANSI.swift
+++ b/Sources/Pry/TUI/ANSI.swift
@@ -27,22 +27,34 @@ enum ANSI {
     static let hideCursor = "\u{001B}[?25l"
     static let showCursor = "\u{001B}[?25h"
 
+    // Background — always dark
+    static let bgDark = "\u{001B}[48;2;13;17;23m"        // #0D1117 — logo background
+    static let bgPanel = "\u{001B}[48;2;22;27;34m"       // #161B22 — slightly lighter for panels
+    static let bgSelected = "\u{001B}[48;2;33;38;45m"    // #21262D — selected row
+    static let bgHeader = "\u{001B}[48;2;40;50;65m"      // #283241 — panel headers
+    static let bgStatus = "\u{001B}[48;2;0;100;120m"     // teal status bar
+
+    // Foreground
+    static let fgWhite = "\u{001B}[38;2;230;237;243m"    // #E6EDF3 — bright text
+    static let fgDim = "\u{001B}[38;2;125;133;144m"      // #7D8590 — dimmed text
+    static let fgCyanBright = "\u{001B}[38;2;0;229;255m"  // #00E5FF — logo cyan
+    static let fgGreen = "\u{001B}[38;2;63;185;80m"       // #3FB950 — success
+    static let fgCyan = "\u{001B}[38;2;88;166;255m"       // #58A6FF — response/info
+    static let fgRed = "\u{001B}[38;2;248;81;73m"         // #F85149 — error
+    static let fgYellow = "\u{001B}[38;2;210;153;34m"     // #D29922 — mock/warning
+    static let fgBlue = "\u{001B}[38;2;88;166;255m"       // #58A6FF — info
+    static let fgGray = "\u{001B}[38;2;110;118;129m"      // #6E7681 — tunnel/secondary
+
     // Style
-    static let reset = "\u{001B}[0m"
+    static let rawReset = "\u{001B}[0m"
+    static let reset = "\u{001B}[0m\u{001B}[48;2;13;17;23m\u{001B}[38;2;230;237;243m" // reset + dark bg + white fg
     static let bold = "\u{001B}[1m"
     static let dim = "\u{001B}[2m"
     static let inverse = "\u{001B}[7m"
 
-    // Colors
-    static let fgGreen = "\u{001B}[32m"
-    static let fgCyan = "\u{001B}[36m"
-    static let fgRed = "\u{001B}[31m"
-    static let fgYellow = "\u{001B}[33m"
-    static let fgBlue = "\u{001B}[34m"
-    static let fgGray = "\u{001B}[90m"
-    static let fgWhite = "\u{001B}[37m"
-    static let bgBlue = "\u{001B}[44m"
-    static let bgGray = "\u{001B}[100m"
+    // Legacy aliases for Colors.swift compatibility
+    static let bgBlue = bgStatus
+    static let bgGray = bgHeader
 
     // Terminal size
     static func getSize() -> (rows: Int, cols: Int) {

--- a/Sources/Pry/TUI/TUI.swift
+++ b/Sources/Pry/TUI/TUI.swift
@@ -43,7 +43,12 @@ class TUI {
         cols = size.cols
 
         terminal.enableRawMode()
-        ANSI.write(ANSI.enterAltBuffer + ANSI.hideCursor + ANSI.clearScreen)
+        // Enter alt buffer, hide cursor, set dark background, fill screen
+        var initBuf = ANSI.enterAltBuffer + ANSI.hideCursor + ANSI.bgDark + ANSI.fgWhite
+        for r in 1...rows {
+            initBuf += ANSI.moveTo(row: r, col: 1) + String(repeating: " ", count: cols)
+        }
+        ANSI.write(initBuf)
 
         // Register for traffic updates
         broker.setTUIMode { [weak self] _ in
@@ -65,7 +70,7 @@ class TUI {
         broker.setHeadlessMode()
         store.onChange = nil
         terminal.disableRawMode()
-        ANSI.write(ANSI.showCursor + ANSI.exitAltBuffer)
+        ANSI.write(ANSI.rawReset + ANSI.showCursor + ANSI.exitAltBuffer)
     }
 
     // MARK: - Splash Screen
@@ -82,11 +87,14 @@ class TUI {
         ]
 
         let startRow = max(1, (rows - cat.count) / 2 - 2)
-        var buf = ANSI.clearScreen
+        var buf = ANSI.bgDark + ANSI.fgWhite
+        for r in 1...rows {
+            buf += ANSI.moveTo(row: r, col: 1) + String(repeating: " ", count: cols)
+        }
 
         for (i, line) in cat.enumerated() {
             let col = max(1, (cols - 42) / 2)
-            buf += ANSI.moveTo(row: startRow + i, col: col) + ANSI.fgCyan + line + ANSI.reset
+            buf += ANSI.moveTo(row: startRow + i, col: col) + ANSI.fgCyanBright + line + ANSI.reset + ANSI.bgDark
         }
 
         // Subtitle
@@ -211,33 +219,28 @@ class TUI {
 
     // MARK: - Layout Geometry
 
-    private var listWidth: Int { max(cols / 3, 25) }
-    private var detailWidth: Int { cols - listWidth - 1 } // -1 for border
-    private var contentHeight: Int { max(rows - 3, 4) } // -1 status, -1 separator, -1 cmdline
-    private var detailSplitRow: Int { 1 + 1 + contentHeight / 2 } // after status + half content
+    private var listWidth: Int { max(cols * 35 / 100, 30) }
+    private var detailCol: Int { listWidth + 2 }
+    private var detailWidth: Int { cols - listWidth - 2 }
+    private var contentTop: Int { 3 } // row 1=status, 2=panel headers, 3+=content
+    private var contentHeight: Int { max(rows - 4, 4) } // -1 status -1 headers -1 separator -1 cmd
 
     // MARK: - Full Render
 
     private func renderFull() {
-        var buf = ANSI.clearScreen
+        // Fill with dark background
+        var buf = ANSI.bgDark + ANSI.fgWhite
+        for r in 1...rows {
+            buf += ANSI.moveTo(row: r, col: 1) + String(repeating: " ", count: cols)
+        }
 
-        // Status bar (row 1)
         buf += renderStatusBar()
+        buf += renderPanelHeaders()
 
-        // Content area: list (left) + detail (right)
         let requests = store.getAll()
         buf += renderListContent(requests)
         buf += renderDetailContent(requests)
-
-        // Vertical border between list and detail
-        for r in 2...contentHeight + 1 {
-            buf += ANSI.moveTo(row: r, col: listWidth + 1) + ANSI.dim + "│" + ANSI.reset
-        }
-
-        // Bottom separator
-        buf += ANSI.moveTo(row: rows - 1, col: 1) + ANSI.dim + String(repeating: "─", count: cols) + ANSI.reset
-
-        // Command line
+        buf += renderBorders()
         buf += renderCommandLineStr()
 
         ANSI.write(buf)
@@ -249,9 +252,52 @@ class TUI {
         let watchlist = Watchlist.load()
         let mocks = Config.loadMocks()
         let count = store.count()
-        let status = " 🐱 :\(port) │ \(watchlist.count) domains │ \(mocks.count) mocks │ \(count) requests │ ↑↓ nav │ [Tab] mocks │ q quit "
-        let padded = status.padding(toLength: cols, withPad: " ", startingAt: 0)
-        return ANSI.moveTo(row: 1, col: 1) + ANSI.inverse + padded + ANSI.reset
+
+        // Left: info
+        let left = " 🐱 Pry :\(port)"
+        // Center: stats
+        let center = "\(watchlist.count) domains │ \(mocks.count) mocks │ \(count) reqs"
+        // Right: help
+        let right = "↑↓ nav │ Tab mocks │ q quit "
+
+        let padding = max(0, cols - left.count - center.count - right.count)
+        let leftPad = padding / 2
+        let rightPad = padding - leftPad
+
+        let status = left + String(repeating: " ", count: leftPad) + center + String(repeating: " ", count: rightPad) + right
+        let padded = String(status.prefix(cols)).padding(toLength: cols, withPad: " ", startingAt: 0)
+        return ANSI.moveTo(row: 1, col: 1) + ANSI.bgStatus + ANSI.fgWhite + ANSI.bold + padded + ANSI.rawReset
+    }
+
+    // MARK: - Panel Headers
+
+    private func renderPanelHeaders() -> String {
+        var buf = ""
+
+        // List header
+        let listHeader = " METHOD  STATUS  HOST"
+        let listPadded = String(listHeader.prefix(listWidth - 1)).padding(toLength: listWidth - 1, withPad: " ", startingAt: 0)
+        buf += ANSI.moveTo(row: 2, col: 1) + ANSI.bgHeader + ANSI.fgWhite + listPadded + ANSI.rawReset
+
+        // Detail header
+        let detailHeader = showMocks ? " 📋 ACTIVE MOCKS" : " 📄 REQUEST / RESPONSE DETAIL"
+        let detailPadded = String(detailHeader.prefix(detailWidth)).padding(toLength: detailWidth, withPad: " ", startingAt: 0)
+        buf += ANSI.moveTo(row: 2, col: detailCol) + ANSI.bgHeader + ANSI.fgWhite + detailPadded + ANSI.rawReset
+
+        return buf
+    }
+
+    // MARK: - Borders
+
+    private func renderBorders() -> String {
+        var buf = ""
+        // Vertical separator
+        for r in 2...(contentTop + contentHeight) {
+            buf += ANSI.moveTo(row: r, col: listWidth) + ANSI.bgDark + ANSI.fgGray + "│" + ANSI.reset
+        }
+        // Bottom separator
+        buf += ANSI.moveTo(row: rows - 1, col: 1) + ANSI.bgDark + ANSI.fgGray + String(repeating: "─", count: cols) + ANSI.reset
+        return buf
     }
 
     // MARK: - Request List (Left Panel)
@@ -265,48 +311,42 @@ class TUI {
         var buf = ""
         let height = contentHeight
 
-        // Adjust scroll to keep selected visible
-        if selectedIndex < listScrollOffset {
-            listScrollOffset = selectedIndex
-        }
-        if selectedIndex >= listScrollOffset + height {
-            listScrollOffset = selectedIndex - height + 1
-        }
+        // Adjust scroll
+        if selectedIndex < listScrollOffset { listScrollOffset = selectedIndex }
+        if selectedIndex >= listScrollOffset + height { listScrollOffset = selectedIndex - height + 1 }
 
         for i in 0..<height {
-            let row = 2 + i
+            let row = contentTop + i
             let idx = listScrollOffset + i
             buf += ANSI.moveTo(row: row, col: 1)
 
             if idx < requests.count {
                 let req = requests[idx]
                 let isSelected = idx == selectedIndex
-                let prefix = isSelected ? "►" : " "
 
-                // Color by type
-                let methodColor: String
-                if req.isMock {
-                    methodColor = ANSI.fgYellow
-                } else if req.isTunnel {
-                    methodColor = ANSI.fgGray
-                } else if let code = req.statusCode, code >= 400 {
-                    methodColor = ANSI.fgRed
-                } else {
-                    methodColor = ANSI.fgGreen
-                }
+                // Status indicator
+                let statusIcon: String
+                if req.isMock { statusIcon = "🟡" }
+                else if req.isTunnel { statusIcon = "🔒" }
+                else if let code = req.statusCode {
+                    statusIcon = code < 400 ? "🟢" : "🔴"
+                } else { statusIcon = "⏳" }
 
-                let status = req.statusCode.map { "\($0)" } ?? "..."
-                let line = "\(prefix) \(req.appIcon) \(req.method) \(status) \(req.host)"
-                let truncated = String(line.prefix(listWidth - 1))
-                let padded = truncated.padding(toLength: listWidth - 1, withPad: " ", startingAt: 0)
+                let method = req.method.padding(toLength: 7, withPad: " ", startingAt: 0)
+                let status = (req.statusCode.map { "\($0)" } ?? "···").padding(toLength: 5, withPad: " ", startingAt: 0)
+                let hostMax = listWidth - 18
+                let host = String(req.host.prefix(hostMax))
+
+                let line = " \(statusIcon) \(method) \(status) \(host)"
+                let padded = String(line.prefix(listWidth - 1)).padding(toLength: listWidth - 1, withPad: " ", startingAt: 0)
 
                 if isSelected {
-                    buf += ANSI.inverse + methodColor + padded + ANSI.reset
+                    buf += ANSI.bgSelected + ANSI.fgCyanBright + ANSI.bold + padded + ANSI.reset
                 } else {
-                    buf += methodColor + padded + ANSI.reset
+                    buf += ANSI.bgDark + ANSI.fgWhite + padded + ANSI.reset
                 }
             } else {
-                buf += String(repeating: " ", count: listWidth - 1)
+                buf += ANSI.bgDark + String(repeating: " ", count: listWidth - 1) + ANSI.reset
             }
         }
         return buf
@@ -321,102 +361,118 @@ class TUI {
 
     private func renderDetailContent(_ requests: [RequestStore.CapturedRequest]) -> String {
         var buf = ""
-        let startCol = listWidth + 2
-        let width = detailWidth - 1
-        let height = contentHeight
+        let sc = detailCol // start col
+        let w = detailWidth - 1
+        let h = contentHeight
 
         if showMocks {
-            return renderMocksView(startCol: startCol, width: width, height: height)
+            return renderMocksView(startCol: sc, width: w, height: h)
         }
 
         guard selectedIndex < requests.count else {
-            // Empty state
-            for i in 0..<height {
-                buf += ANSI.moveTo(row: 2 + i, col: startCol) + String(repeating: " ", count: width)
-            }
-            buf += ANSI.moveTo(row: 2 + height / 2, col: startCol)
-            buf += ANSI.dim + "No request selected" + ANSI.reset
-            return buf
+            return renderEmptyState(startCol: sc, width: w, height: h)
         }
 
         let req = requests[selectedIndex]
-        let halfHeight = height / 2
+        let halfH = h / 2
         var line = 0
 
-        // Request section header
-        buf += writeLine(row: 2, col: startCol, width: width, text: ANSI.bold + ANSI.fgGreen + " Request" + ANSI.reset)
+        // ── Request ──
+        let reqTitle = "── Request ─" + String(repeating: "─", count: max(0, w - 13))
+        buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.fgGreen + ANSI.bold + reqTitle + ANSI.reset)
         line += 1
 
-        // Request info
-        buf += writeLine(row: 2 + line, col: startCol, width: width, text: " \(req.method) \(req.url)")
-        line += 1
-        buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " Host: \(req.host)" + ANSI.reset)
-        line += 1
-        buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " App: \(req.appIcon) \(req.appName)" + ANSI.reset)
+        buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.fgGreen + " \(req.method) " + ANSI.reset + req.url)
         line += 1
 
-        // Request headers
-        for (name, value) in req.requestHeaders.prefix(4) {
-            if line >= halfHeight { break }
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " \(name): \(value)" + ANSI.reset)
+        buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + " \(req.appIcon) \(req.appName) → \(req.host)" + ANSI.reset)
+        line += 1
+
+        for (name, value) in req.requestHeaders.prefix(5) {
+            if line >= halfH { break }
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + " \(name): " + ANSI.reset + value)
             line += 1
         }
 
-        // Request body
-        if let body = req.requestBody, !body.isEmpty, line < halfHeight {
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " Body: \(body.prefix(width - 7))" + ANSI.reset)
+        if let body = req.requestBody, !body.isEmpty, line < halfH {
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + " Body: " + ANSI.reset + String(body.prefix(w - 7)))
             line += 1
         }
 
-        // Clear remaining request lines
-        while line < halfHeight {
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: "")
+        while line < halfH {
+            buf += dl(row: contentTop + line, col: sc, w: w, text: "")
             line += 1
         }
 
-        // Separator
-        buf += ANSI.moveTo(row: 2 + halfHeight, col: startCol)
-        buf += ANSI.dim + String(repeating: "─", count: width) + ANSI.reset
-
-        // Response section
-        line = halfHeight + 1
-
+        // ── Response ──
+        let respTitle: String
         if req.isTunnel {
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.fgGray + " 🔒 Tunnel (encrypted passthrough)" + ANSI.reset)
+            respTitle = "── Tunnel ─" + String(repeating: "─", count: max(0, w - 12))
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.fgGray + ANSI.bold + respTitle + ANSI.reset)
+            line += 1
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.fgGray + " 🔒 Encrypted passthrough — not intercepted" + ANSI.reset)
             line += 1
         } else if let code = req.statusCode {
-            let statusColor = code < 400 ? ANSI.fgCyan : ANSI.fgRed
-            let mockTag = req.isMock ? ANSI.fgYellow + " MOCK" + ANSI.reset : ""
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.bold + statusColor + " Response \(code)" + ANSI.reset + mockTag)
+            let color = code < 400 ? ANSI.fgCyan : ANSI.fgRed
+            let mockLabel = req.isMock ? " 🟡 MOCK" : ""
+            respTitle = "── Response \(code)\(mockLabel) " + String(repeating: "─", count: max(0, w - 18 - mockLabel.count))
+            buf += dl(row: contentTop + line, col: sc, w: w, text: color + ANSI.bold + respTitle + ANSI.reset)
             line += 1
 
-            // Response headers
-            for (name, value) in req.responseHeaders.prefix(4) {
-                if line >= height { break }
-                buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " \(name): \(value)" + ANSI.reset)
+            for (name, value) in req.responseHeaders.prefix(5) {
+                if line >= h { break }
+                buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + " \(name): " + ANSI.reset + value)
                 line += 1
             }
 
-            // Response body
             if let body = req.responseBody, !body.isEmpty {
                 let bodyLines = body.split(separator: "\n", omittingEmptySubsequences: false)
-                for bodyLine in bodyLines.prefix(height - line) {
-                    if line >= height { break }
-                    buf += writeLine(row: 2 + line, col: startCol, width: width, text: " \(bodyLine)")
+                for bodyLine in bodyLines.prefix(h - line) {
+                    if line >= h { break }
+                    buf += dl(row: contentTop + line, col: sc, w: w, text: " " + String(bodyLine))
                     line += 1
                 }
             }
         } else {
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + " Waiting for response..." + ANSI.reset)
+            respTitle = "── Response ─" + String(repeating: "─", count: max(0, w - 14))
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + respTitle + ANSI.reset)
+            line += 1
+            buf += dl(row: contentTop + line, col: sc, w: w, text: ANSI.dim + " ⏳ Waiting..." + ANSI.reset)
             line += 1
         }
 
-        // Clear remaining
-        while line < height {
-            buf += writeLine(row: 2 + line, col: startCol, width: width, text: "")
+        while line < h {
+            buf += dl(row: contentTop + line, col: sc, w: w, text: "")
             line += 1
         }
 
+        return buf
+    }
+
+    // MARK: - Empty State
+
+    private func renderEmptyState(startCol: Int, width: Int, height: Int) -> String {
+        var buf = ""
+        let catLines = [
+            "   ╱|、",
+            "  (˚ˎ 。7",
+            "   |、˜〵",
+            "   じしˍ,)ノ",
+            "",
+            "  Waiting for requests...",
+            "  Send traffic through :\(port)",
+        ]
+
+        let startRow = contentTop + max(0, (height - catLines.count) / 2)
+        for i in 0..<height {
+            let row = contentTop + i
+            if i >= (height - catLines.count) / 2 && (i - (height - catLines.count) / 2) < catLines.count {
+                let catIdx = i - (height - catLines.count) / 2
+                buf += dl(row: row, col: startCol, w: width, text: ANSI.fgCyan + catLines[catIdx] + ANSI.reset)
+            } else {
+                buf += dl(row: row, col: startCol, w: width, text: "")
+            }
+        }
         return buf
     }
 
@@ -425,33 +481,34 @@ class TUI {
     private func renderMocksView(startCol: Int, width: Int, height: Int) -> String {
         var buf = ""
         let mocks = Config.loadMocks()
+        var line = 0
 
-        buf += writeLine(row: 2, col: startCol, width: width, text: ANSI.bold + ANSI.fgYellow + " Active Mocks" + ANSI.reset)
+        let title = "── Active Mocks [Tab to close] " + String(repeating: "─", count: max(0, width - 32))
+        buf += dl(row: contentTop, col: startCol, w: width, text: ANSI.fgYellow + ANSI.bold + title + ANSI.reset)
+        line += 1
 
         if mocks.isEmpty {
-            buf += writeLine(row: 3, col: startCol, width: width, text: ANSI.dim + " No mocks registered" + ANSI.reset)
-            for i in 4..<height + 2 {
-                buf += writeLine(row: i, col: startCol, width: width, text: "")
-            }
+            buf += dl(row: contentTop + line, col: startCol, w: width, text: ANSI.dim + " No mocks registered" + ANSI.reset)
+            line += 1
+            buf += dl(row: contentTop + line, col: startCol, w: width, text: ANSI.dim + " Use: mock /path '{\"key\":\"value\"}'" + ANSI.reset)
+            line += 1
         } else {
-            var line = 1
             for (path, response) in mocks {
                 if line >= height { break }
-                buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.fgYellow + " \(path)" + ANSI.reset)
+                buf += dl(row: contentTop + line, col: startCol, w: width, text: ANSI.fgYellow + " ● " + ANSI.reset + path)
                 line += 1
                 if line < height {
-                    let preview = String(response.prefix(width - 4))
-                    buf += writeLine(row: 2 + line, col: startCol, width: width, text: ANSI.dim + "   \(preview)" + ANSI.reset)
+                    let preview = String(response.prefix(width - 6))
+                    buf += dl(row: contentTop + line, col: startCol, w: width, text: ANSI.dim + "   → \(preview)" + ANSI.reset)
                     line += 1
                 }
             }
-            while line < height {
-                buf += writeLine(row: 2 + line, col: startCol, width: width, text: "")
-                line += 1
-            }
         }
 
-        buf += writeLine(row: 2, col: startCol, width: width, text: ANSI.bold + ANSI.fgYellow + " Active Mocks [Tab to close]" + ANSI.reset)
+        while line < height {
+            buf += dl(row: contentTop + line, col: startCol, w: width, text: "")
+            line += 1
+        }
         return buf
     }
 
@@ -462,18 +519,22 @@ class TUI {
     }
 
     private func renderCommandLineStr() -> String {
-        let prompt = "pry> "
+        let prompt = " pry❯ "
         let maxInput = cols - prompt.count - 1
         let displayInput = String(commandBuffer.suffix(maxInput))
         let cursorCol = prompt.count + displayInput.count + 1
-        return ANSI.moveTo(row: rows, col: 1) + ANSI.clearLine +
-               ANSI.fgCyan + ANSI.bold + prompt + ANSI.reset + displayInput +
+        let pad = String(repeating: " ", count: max(0, cols - prompt.count - displayInput.count))
+        return ANSI.moveTo(row: rows, col: 1) + ANSI.bgDark +
+               ANSI.fgCyanBright + ANSI.bold + prompt + ANSI.reset +
+               ANSI.bgDark + ANSI.fgWhite + displayInput + pad +
                ANSI.showCursor + ANSI.moveTo(row: rows, col: cursorCol)
     }
 
     // MARK: - Helpers
 
-    private func writeLine(row: Int, col: Int, width: Int, text: String) -> String {
-        ANSI.moveTo(row: row, col: col) + ANSI.clearToEnd + String(text.prefix(width))
+    /// Draw line: move to position, fill with panel bg, write text truncated to width
+    private func dl(row: Int, col: Int, w: Int, text: String) -> String {
+        ANSI.moveTo(row: row, col: col) + ANSI.bgPanel + ANSI.fgWhite + String(repeating: " ", count: w) +
+        ANSI.moveTo(row: row, col: col) + ANSI.bgPanel + text + ANSI.reset
     }
 }


### PR DESCRIPTION
## Summary
Complete visual overhaul of the TUI using a cohesive dark color palette matching the Pry logo (#0D1117 background, #00E5FF cyan accents).

**Before:** White patches, inconsistent backgrounds, reset codes restoring terminal default.
**After:** Full dark theme with proper contrast and depth.

### Color palette (all RGB):
- Background: #0D1117 (dark navy) / #161B22 (panels) / #21262D (selected)
- Text: #E6EDF3 (bright) / #7D8590 (dim) / #6E7681 (borders)
- Accents: #3FB950 (green) / #58A6FF (cyan) / #F85149 (red) / #D29922 (yellow)
- Logo: #00E5FF (bright cyan)

### Key fix:
Custom `reset` escape code that always restores dark bg + white fg instead of terminal default. This eliminates all white patches.

## Test plan
- [ ] TUI has dark background everywhere (no white patches)
- [ ] Text is readable with good contrast
- [ ] Selected row visually distinct
- [ ] Splash screen uses logo cyan
- [ ] Terminal restores correctly on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)