### PR TITLE
feat: implement missing features (v0.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: swift build
 
+      - name: Test
+        run: swift test
+
       - name: Build Release
         run: swift build -c release
 
@@ -141,6 +144,9 @@ jobs:
 
       - name: Build
         run: swift build
+
+      - name: Test
+        run: swift test
 
       - name: Build Release
         run: swift build -c release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,27 @@
 
 ```
 Sources/Pry/
-├── main.swift              → Entry point, command dispatch
-├── ProxyServer.swift       → ServerBootstrap, lifecycle
-├── HTTPInterceptor.swift   → Captura HTTP requests, forwarding
-├── ConnectHandler.swift    → CONNECT method, tunnel vs intercept
-├── GlueHandler.swift       → Bidirectional byte forwarding (tunnel)
+├── main.swift                → Entry point, command dispatch
+
+Sources/PryLib/
+├── ProxyServer.swift         → ServerBootstrap, lifecycle
+├── HTTPInterceptor.swift     → Captura HTTP requests, forwarding
+├── ConnectHandler.swift      → CONNECT method, tunnel vs intercept
+├── GlueHandler.swift         → Bidirectional byte forwarding (tunnel)
 ├── CertificateAuthority.swift → CA generation, cert cache
-├── Watchlist.swift         → .prywatch domains management
-├── MockHandler.swift       → Mock responses por path
-├── Config.swift            → .pryconfig, logging, PID
-├── ProxyError.swift        → Errores tipados
+├── Watchlist.swift           → .prywatch domains management
+├── Config.swift              → .pryconfig, logging, PID, mocks
+├── ProxyError.swift          → Errores tipados
+├── CurlGenerator.swift       → Genera comandos curl desde requests
+├── BodyPrinter.swift         → Pretty-print de request/response bodies
+├── AppIdentifier.swift       → Identifica apps por User-Agent
+├── Colors.swift              → ANSI color helpers
+├── TUI/
+│   ├── TUI.swift             → TUI interactiva (3 paneles, keybindings)
+│   ├── RequestStore.swift    → Almacen de requests capturados en memoria
+│   ├── OutputBroker.swift    → Coordinacion de output TUI/headless
+│   ├── ANSI.swift            → Secuencias de control de terminal
+│   └── Terminal.swift        → Raw mode management
 ```
 
 ## Workflow de desarrollo
@@ -84,8 +95,18 @@ pry mock PATH JSON          # Registra mock
 pry mocks [clear]           # Lista/limpia mocks
 pry log [clear]             # Muestra/limpia log
 pry watch PATTERN           # Filtra trafico por dominio
+pry watch clear             # Limpia filtro
 pry trust                   # Instala CA en iOS Simulator
 pry ca                      # Info del CA certificate
+pry break PATTERN           # Breakpoint en URL pattern
+pry breaks [clear]          # Lista/limpia breakpoints
+pry init [DIR]              # Escanea proyecto para .prywatch
+```
+
+### Flags
+```bash
+pry start --port PORT       # Puerto custom (default: 8080)
+pry start --headless        # Sin TUI, solo logging a stdout
 ```
 
 ## Testing

--- a/Formula/pry.rb
+++ b/Formula/pry.rb
@@ -1,0 +1,23 @@
+class Pry < Formula
+  desc "HTTP/HTTPS proxy CLI for iOS devs — Swift puro, un binario"
+  homepage "https://github.com/fsaldivar-dev/pry"
+  url "https://github.com/fsaldivar-dev/pry/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 ""  # Update with actual sha256 after release
+  license "MIT"
+
+  depends_on xcode: ["14.0", :build]
+  depends_on :macos
+
+  def install
+    system "swift", "build",
+           "-c", "release",
+           "--disable-sandbox",
+           "--arch", "arm64",
+           "--arch", "x86_64"
+    bin.install ".build/release/pry"
+  end
+
+  test do
+    assert_match "Pry", shell_output("#{bin}/pry help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 
 <h2 id="inicio-rápido">Inicio rápido</h2>
 
+### Homebrew (recomendado)
+
 ```bash
-# Compilar
+brew tap fsaldivar-dev/pry
+brew install pry
+```
+
+### Desde fuente
+
+```bash
 swift build -c release
 cp .build/release/pry /usr/local/bin/pry
 
@@ -100,6 +108,45 @@ pry start
 pry log          # Historial de requests
 pry list         # Dominios interceptados
 pry mocks        # Mocks activos
+```
+
+### TUI interactiva
+
+Al ejecutar `pry start`, se abre una interfaz interactiva en terminal con 3 paneles: lista de requests, detalle, y response body.
+
+```bash
+pry start              # TUI interactiva (default)
+pry start --headless   # Sin TUI, solo logging a stdout
+pry start --port 9090  # Puerto custom
+```
+
+**Keybindings:**
+
+| Tecla | Acción |
+|-------|--------|
+| `↑` `↓` | Navegar requests |
+| `c` | Copiar request como cURL al clipboard |
+| `f` | Ciclar filtros (GET → POST → PUT → DELETE → 2xx → 4xx → 5xx) |
+| `/` | Buscar por URL, host, método o body |
+| `Tab` | Alternar entre requests y mocks activos |
+| `Esc` | Limpiar filtro/búsqueda |
+| `q` | Salir |
+
+**Indicadores:**
+
+| Icono | Significado |
+|-------|-------------|
+| 🟢 | Respuesta exitosa (2xx) |
+| 🔴 | Error (4xx/5xx) |
+| 🟡 | Respuesta mockeada |
+| 🔒 | Túnel HTTPS (no interceptado) |
+| ⏳ | Esperando respuesta |
+
+### Filtrar tráfico
+
+```bash
+pry watch api.myapp.com   # Solo mostrar tráfico de este dominio
+pry watch clear           # Limpiar filtro
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,22 +14,31 @@
 - [x] `pry trust` — instalar CA en Simulator
 - [x] HTTPS tunneling (GlueHandler + state machine fix)
 - [x] TLS interception (MITM pipeline)
-- [ ] Detección de certificate pinning
+- [x] Detección de certificate pinning
 
-## v0.3 — Testing & Quality
-- [ ] Separar en PryLib + Pry (library + executable)
-- [ ] Unit tests para Watchlist, Config, MockHandler
+## v0.3 — Testing & Quality ✅
+- [x] Separar en PryLib + Pry (library + executable)
+- [x] Unit tests (Watchlist, Config, RequestStore, CurlGenerator, AppIdentifier, ProxyError, BreakpointStore, WSFrame, ProjectScanner, CertPinning)
+- [x] CI con `swift test` (macOS + Linux)
 - [ ] Integration tests con proxy real
-- [ ] CI con swift test
 
-## v0.4 — Developer Experience
-- [ ] `pry init` — genera .prywatch desde el proyecto
-- [ ] Colores en stdout (request verde, response azul, error rojo)
-- [ ] Request/response body preview (truncado)
-- [ ] Export log a HAR format
+## v0.4 — Developer Experience ✅
+- [x] TUI interactiva (3 paneles, keybindings, filtros, búsqueda)
+- [x] Colores en stdout (Colors.swift, ANSI.swift)
+- [x] Request/response body preview (BodyPrinter)
+- [x] Copiar request como cURL (CurlGenerator)
+- [x] Identificación de apps por User-Agent (AppIdentifier)
+- [x] Modo headless (`--headless`)
+- [x] `pry init` — genera .prywatch desde el proyecto
+
+## v0.5 — Advanced Features ✅
+- [x] WebSocket interception (RFC 6455 frame parsing)
+- [x] Breakpoints (pausar y modificar requests)
+- [x] Homebrew formula
 
 ## Futuro
-- [ ] WebSocket interception
-- [ ] Breakpoints (pausar y modificar requests)
+- [ ] Export log a HAR format
+- [ ] Header rewrite (`pry header add/remove`)
+- [ ] Map local (`pry map REGEX FILE`)
+- [ ] Request replay desde CLI
 - [ ] Integración con AutoPilot
-- [ ] Homebrew formula

--- a/Sources/Pry/main.swift
+++ b/Sources/Pry/main.swift
@@ -37,6 +37,10 @@ func printUsage() {
       pry headers                List active header rules
       pry headers clear          Clear all header rules
       pry export har FILE        Export traffic as HAR 1.2
+      pry break PATTERN          Set breakpoint on URL pattern
+      pry breaks                 List active breakpoints
+      pry breaks clear           Clear all breakpoints
+      pry init [DIR]             Scan project for API domains → .prywatch
 
     Examples:
       pry start
@@ -580,6 +584,52 @@ case "export":
     } catch {
         print("Error: \(error)")
         exit(1)
+    }
+
+case "break":
+    guard args.count >= 2 else {
+        print("Usage: pry break /api/login")
+        print("       pry break *.myapp.com")
+        exit(1)
+    }
+    let pattern = args[1]
+    BreakpointStore.shared.add(pattern)
+    print("🐱 Breakpoint added: \(pattern)")
+    print("   Requests matching this pattern will be paused in TUI")
+
+case "breaks":
+    if args.count >= 2 && args[1] == "clear" {
+        BreakpointStore.shared.clearAll()
+        print("🐱 All breakpoints cleared")
+    } else {
+        let patterns = BreakpointStore.shared.all()
+        if patterns.isEmpty {
+            print("🐱 No breakpoints set")
+            print("   Add one with: pry break /api/login")
+        } else {
+            print("🐱 Active breakpoints:")
+            for pattern in patterns {
+                print("   ⏸️  \(pattern)")
+            }
+        }
+    }
+
+case "init":
+    let dir = args.count >= 2 ? args[1] : FileManager.default.currentDirectoryPath
+    print("🐱 Scanning \(dir) for API domains...")
+    let domains = ProjectScanner.scan(directory: dir)
+    if domains.isEmpty {
+        print("   No domains found. Add them manually with: pry add DOMAIN")
+    } else {
+        for domain in domains {
+            Watchlist.add(domain)
+        }
+        print("   Found \(domains.count) domain(s):")
+        for domain in domains {
+            print("   + \(domain)")
+        }
+        print("\n   Written to .prywatch")
+        print("   Run 'pry trust' to install CA, then 'pry start'")
     }
 
 case "help", "--help", "-h":

--- a/Sources/PryLib/BreakpointStore.swift
+++ b/Sources/PryLib/BreakpointStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Manages URL patterns for request breakpoints
+public class BreakpointStore {
+    public static let shared = BreakpointStore()
+
+    private let queue = DispatchQueue(label: "pry.breakpoints")
+    private var patterns: [String] = []
+
+    private static let breakpointsFile = "/tmp/pry.breakpoints"
+
+    init() {
+        load()
+    }
+
+    /// Add a URL pattern to break on (e.g., "/api/login", "*.myapp.com")
+    public func add(_ pattern: String) {
+        queue.sync {
+            if !patterns.contains(pattern) {
+                patterns.append(pattern)
+            }
+        }
+        save()
+    }
+
+    /// Remove a breakpoint pattern
+    public func remove(_ pattern: String) {
+        queue.sync {
+            patterns.removeAll { $0 == pattern }
+        }
+        save()
+    }
+
+    /// Clear all breakpoints
+    public func clearAll() {
+        queue.sync { patterns.removeAll() }
+        save()
+    }
+
+    /// Get all patterns
+    public func all() -> [String] {
+        queue.sync { patterns }
+    }
+
+    /// Check if a URL should be paused
+    public func shouldBreak(url: String, host: String) -> Bool {
+        return queue.sync {
+            for pattern in patterns {
+                if matchesPattern(pattern, url: url, host: host) {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+
+    private func matchesPattern(_ pattern: String, url: String, host: String) -> Bool {
+        // Glob-style matching
+        if pattern.contains("*") {
+            let regex = pattern
+                .replacingOccurrences(of: ".", with: "\\.")
+                .replacingOccurrences(of: "*", with: ".*")
+            return (try? NSRegularExpression(pattern: "^\(regex)", options: []))
+                .map { $0.firstMatch(in: url, range: NSRange(url.startIndex..., in: url)) != nil
+                    || $0.firstMatch(in: host, range: NSRange(host.startIndex..., in: host)) != nil }
+                ?? false
+        }
+
+        // Simple prefix match on URL path
+        return url.contains(pattern) || host.contains(pattern)
+    }
+
+    private func save() {
+        let content = queue.sync { patterns.joined(separator: "\n") }
+        try? content.write(toFile: Self.breakpointsFile, atomically: true, encoding: .utf8)
+    }
+
+    private func load() {
+        guard let content = try? String(contentsOfFile: Self.breakpointsFile, encoding: .utf8) else { return }
+        let loaded = content.split(separator: "\n").map(String.init).filter { !$0.isEmpty }
+        queue.sync { patterns = loaded }
+    }
+}

--- a/Sources/PryLib/CertificatePinningDetector.swift
+++ b/Sources/PryLib/CertificatePinningDetector.swift
@@ -1,0 +1,63 @@
+import NIO
+import NIOCore
+import NIOTLS
+import Foundation
+
+/// Detects probable certificate pinning by monitoring client behavior
+/// after TLS handshake with our MITM certificate.
+///
+/// Heuristic: if the client closes the connection without sending any
+/// HTTP data after completing the TLS handshake, the app likely rejected
+/// our certificate due to certificate pinning.
+final class CertificatePinningDetector: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = ByteBuffer
+
+    private let host: String
+    private var handshakeComplete = false
+    private var receivedHTTPData = false
+    private var reported = false
+
+    init(host: String) {
+        self.host = host
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if let tlsEvent = event as? TLSUserEvent, case .handshakeCompleted = tlsEvent {
+            handshakeComplete = true
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        receivedHTTPData = true
+        context.fireChannelRead(data)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        if handshakeComplete && !receivedHTTPData && !reported {
+            reported = true
+            let msg = "📌 \(host) — posible certificate pinning detectado (conexión cerrada sin datos HTTP)"
+            OutputBroker.shared.log(errText(msg), type: .error)
+            Config.appendLog("PINNING \(host)")
+
+            let id = RequestStore.shared.addRequest(
+                method: "CONNECT",
+                url: host,
+                host: host,
+                appIcon: "📌",
+                appName: "pinned",
+                headers: [],
+                body: nil
+            )
+            RequestStore.shared.updateResponse(
+                id: id,
+                statusCode: 0,
+                headers: [],
+                body: "Certificate pinning detected — app rejected MITM certificate",
+                isMock: false
+            )
+            RequestStore.shared.markPinned(id: id)
+        }
+        context.fireChannelInactive()
+    }
+}

--- a/Sources/PryLib/ConnectHandler.swift
+++ b/Sources/PryLib/ConnectHandler.swift
@@ -204,8 +204,11 @@ final class ConnectHandler: ChannelInboundHandler, RemovableChannelHandler {
                 try context.pipeline.syncOperations.removeHandler(interceptor)
             }
 
-            // Add TLS handler, then re-add HTTP handlers for decrypted traffic
+            // Add TLS handler, pinning detector, then re-add HTTP handlers for decrypted traffic
+            let pinningDetector = CertificatePinningDetector(host: host)
             context.pipeline.addHandler(sslHandler, position: .first).flatMap {
+                context.pipeline.addHandler(pinningDetector, position: .after(sslHandler))
+            }.flatMap {
                 context.pipeline.configureHTTPServerPipeline()
             }.flatMap {
                 context.pipeline.addHandler(TLSForwarder(host: host, port: port, eventLoop: context.eventLoop))
@@ -255,6 +258,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
     private let eventLoop: EventLoop
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer: ByteBuffer?
+    private var lastRequestId: Int = 0
 
     init(host: String, port: Int, eventLoop: EventLoop) {
         self.host = host
@@ -280,10 +284,53 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
 
     private func handleDecryptedRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?) {
         let logEntry = "\(head.method) https://\(host)\(head.uri)"
-        BodyPrinter.printRequestHead(head, host: host, port: port)
+        let requestId = BodyPrinter.printRequestHead(head, host: host, port: port)
         BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
+        // WebSocket upgrade detection
+        let upgradeHeader = head.headers["Upgrade"].first?.lowercased()
+        if upgradeHeader == "websocket" {
+            OutputBroker.shared.log(info("🔌 WebSocket upgrade detected: wss://\(host)\(head.uri)"), type: .info)
+            Config.appendLog("WEBSOCKET wss://\(host)\(head.uri)")
+            RequestStore.shared.markWebSocket(id: requestId)
+            forwardWebSocketUpgrade(context: context, head: head, body: body, requestId: requestId)
+            return
+        }
+
+        // Breakpoint check
+        if BreakpointStore.shared.shouldBreak(url: head.uri, host: host) {
+            RequestStore.shared.updateResponse(id: requestId, statusCode: 0, headers: [], body: "⏸️ Paused at breakpoint")
+            let future = RequestBreakpointManager.shared.pause(id: requestId, head: head, body: body, host: host, eventLoop: eventLoop)
+            future.whenSuccess { [self] action in
+                switch action {
+                case .resume:
+                    self.continueRequest(context: context, head: head, body: body, requestId: requestId)
+                case .modify(let newHeaders, let newBody):
+                    var modifiedHead = head
+                    if let headers = newHeaders {
+                        for (name, value) in headers {
+                            modifiedHead.headers.replaceOrAdd(name: name, value: value)
+                        }
+                    }
+                    var modifiedBody = body
+                    if let bodyStr = newBody {
+                        var buf = context.channel.allocator.buffer(capacity: bodyStr.utf8.count)
+                        buf.writeString(bodyStr)
+                        modifiedBody = buf
+                    }
+                    self.continueRequest(context: context, head: modifiedHead, body: modifiedBody, requestId: requestId)
+                case .cancel:
+                    context.close(promise: nil)
+                }
+            }
+            return
+        }
+
+        continueRequest(context: context, head: head, body: body, requestId: requestId)
+    }
+
+    private func continueRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?, requestId: Int) {
         // Check mocks — supports both "domain:path" and simple "/path" formats
         let mocks = Config.loadMocks()
         for (mockKey, response) in mocks {
@@ -346,6 +393,117 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
             OutputBroker.shared.log(errText("!!! TLS context failed: \(error)"))
             context.close(promise: nil)
         }
+    }
+
+    private func forwardWebSocketUpgrade(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?, requestId: Int) {
+        do {
+            let tlsConfig = TLSConfiguration.makeClientConfiguration()
+            let sslContext = try NIOSSLContext(configuration: tlsConfig)
+            let clientChannel = context.channel
+
+            ClientBootstrap(group: eventLoop)
+                .channelInitializer { channel in
+                    let sslHandler = try! NIOSSLClientHandler(context: sslContext, serverHostname: self.host)
+                    return channel.pipeline.addHandler(sslHandler).flatMap {
+                        channel.pipeline.addHTTPClientHandlers()
+                    }.flatMap {
+                        channel.pipeline.addHandler(
+                            WebSocketUpgradeForwarder(
+                                clientChannel: clientChannel,
+                                host: self.host,
+                                requestId: requestId
+                            )
+                        )
+                    }
+                }
+                .connect(host: host, port: port)
+                .whenComplete { result in
+                    switch result {
+                    case .success(let remoteChannel):
+                        var forwardHead = head
+                        forwardHead.headers.replaceOrAdd(name: "Host", value: self.host)
+                        remoteChannel.write(NIOAny(HTTPClientRequestPart.head(forwardHead)), promise: nil)
+                        if let body = body, body.readableBytes > 0 {
+                            remoteChannel.write(NIOAny(HTTPClientRequestPart.body(.byteBuffer(body))), promise: nil)
+                        }
+                        remoteChannel.writeAndFlush(NIOAny(HTTPClientRequestPart.end(nil)), promise: nil)
+                    case .failure(let error):
+                        OutputBroker.shared.log(errText("!!! WebSocket upgrade forward failed to \(self.host): \(error)"))
+                        context.close(promise: nil)
+                    }
+                }
+        } catch {
+            OutputBroker.shared.log(errText("!!! WebSocket TLS context failed: \(error)"))
+            context.close(promise: nil)
+        }
+    }
+}
+
+/// Handles WebSocket upgrade response from server.
+/// On 101, strips HTTP handlers and sets up WebSocket frame interception with GlueHandler.
+final class WebSocketUpgradeForwarder: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPClientResponsePart
+
+    private let clientChannel: Channel
+    private let host: String
+    private let requestId: Int
+
+    init(clientChannel: Channel, host: String, requestId: Int) {
+        self.clientChannel = clientChannel
+        self.host = host
+        self.requestId = requestId
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let part = unwrapInboundIn(data)
+        switch part {
+        case .head(let head):
+            // Forward the upgrade response to client
+            let serverHead = NIOHTTP1.HTTPResponseHead(version: head.version, status: head.status, headers: head.headers)
+            clientChannel.write(NIOAny(HTTPServerResponsePart.head(serverHead)), promise: nil)
+
+            if head.status == .switchingProtocols {
+                OutputBroker.shared.log(info("🔌 WebSocket connection established: wss://\(host)"), type: .info)
+                RequestStore.shared.updateResponse(
+                    id: requestId,
+                    statusCode: UInt(head.status.code),
+                    headers: head.headers.map { ($0.name, $0.value) },
+                    body: "WebSocket connection active"
+                )
+            }
+
+        case .body(var buffer):
+            clientChannel.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
+
+        case .end:
+            clientChannel.writeAndFlush(NIOAny(HTTPServerResponsePart.end(nil)), promise: nil)
+
+            // After 101 response completes, switch to raw WebSocket mode
+            // Remove HTTP handlers and set up bidirectional frame interception
+            let remoteChannel = context.channel
+            let wsInterceptor = WebSocketInterceptor(host: host, requestId: requestId)
+
+            // Set up glue + interceptor on both sides
+            let (localGlue, remoteGlue) = GlueHandler.matchedPair()
+
+            // Remove HTTP handlers from client pipeline and add WS interceptor + glue
+            _ = clientChannel.pipeline.removeHandler(name: "HTTPResponseEncoder")
+            clientChannel.pipeline.addHandler(wsInterceptor).flatMap {
+                self.clientChannel.pipeline.addHandler(localGlue)
+            }.whenComplete { _ in
+                // Remove HTTP handlers from remote pipeline and add glue
+                _ = remoteChannel.pipeline.removeHandler(name: "HTTPRequestEncoder")
+                remoteChannel.pipeline.addHandler(remoteGlue).whenFailure { error in
+                    OutputBroker.shared.log(errText("!!! WebSocket glue setup failed: \(error)"))
+                }
+            }
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        OutputBroker.shared.log(errText("!!! WebSocket upgrade error from \(host): \(error)"))
+        clientChannel.close(promise: nil)
+        context.close(promise: nil)
     }
 }
 

--- a/Sources/PryLib/HTTPInterceptor.swift
+++ b/Sources/PryLib/HTTPInterceptor.swift
@@ -48,6 +48,35 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
         BodyPrinter.printRequestBody(body)
         Config.appendLog(logEntry)
 
+        // Breakpoint check
+        if BreakpointStore.shared.shouldBreak(url: head.uri, host: host) {
+            RequestStore.shared.updateResponse(id: requestId, statusCode: 0, headers: [], body: "⏸️ Paused at breakpoint")
+            let future = RequestBreakpointManager.shared.pause(id: requestId, head: head, body: body, host: host, eventLoop: context.eventLoop)
+            future.whenSuccess { [self] action in
+                switch action {
+                case .resume:
+                    self.continueAfterBreakpoint(context: context, host: host, port: port, path: path, head: head, body: body, requestId: requestId)
+                case .modify(let newHeaders, let newBody):
+                    var modifiedHead = head
+                    if let headers = newHeaders {
+                        for (name, value) in headers {
+                            modifiedHead.headers.replaceOrAdd(name: name, value: value)
+                        }
+                    }
+                    var modifiedBody = body
+                    if let bodyStr = newBody {
+                        var buf = context.channel.allocator.buffer(capacity: bodyStr.utf8.count)
+                        buf.writeString(bodyStr)
+                        modifiedBody = buf
+                    }
+                    self.continueAfterBreakpoint(context: context, host: host, port: port, path: path, head: modifiedHead, body: modifiedBody, requestId: requestId)
+                case .cancel:
+                    context.close(promise: nil)
+                }
+            }
+            return
+        }
+
         // Mock check
         if let mockResponse = findMock(for: path, host: host) {
             respondWithMock(context: context, json: mockResponse, path: path, requestId: requestId)
@@ -67,6 +96,14 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
 
         // Forward to real server
         forwardRequest(context: context, host: host, port: port, head: rewrittenHead, body: body, requestId: requestId)
+    }
+
+    private func continueAfterBreakpoint(context: ChannelHandlerContext, host: String, port: Int, path: String, head: HTTPRequestHead, body: ByteBuffer?, requestId: Int) {
+        if let mockResponse = findMock(for: path, host: host) {
+            respondWithMock(context: context, json: mockResponse, path: path, requestId: requestId)
+            return
+        }
+        forwardRequest(context: context, host: host, port: port, head: head, body: body, requestId: requestId)
     }
 
     private func findMock(for path: String, host: String) -> String? {

--- a/Sources/PryLib/ProjectScanner.swift
+++ b/Sources/PryLib/ProjectScanner.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Scans a project directory for API domains to populate .prywatch
+public struct ProjectScanner {
+
+    /// Common SDK/system domains to exclude from watchlist
+    private static let excludedDomains: Set<String> = [
+        "apple.com", "icloud.com", "mzstatic.com",
+        "googleapis.com", "google.com", "gstatic.com",
+        "facebook.com", "fbcdn.net",
+        "crashlytics.com", "firebaseio.com",
+        "sentry.io", "amplitude.com", "mixpanel.com",
+        "localhost", "127.0.0.1", "example.com",
+    ]
+
+    /// File extensions to scan for domain references
+    private static let sourceExtensions: Set<String> = ["swift", "m", "mm", "h", "plist"]
+
+    /// Regex to match URLs and domains in source code
+    private static let urlPattern = try! NSRegularExpression(
+        pattern: #"https?://([a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)+)"#,
+        options: []
+    )
+
+    /// Regex to match NSExceptionDomains keys in plist XML
+    private static let plistDomainPattern = try! NSRegularExpression(
+        pattern: #"<key>([a-zA-Z0-9][-a-zA-Z0-9]*(?:\.[a-zA-Z0-9][-a-zA-Z0-9]*)+)</key>"#,
+        options: []
+    )
+
+    /// Scan directory and return discovered domains
+    public static func scan(directory: String) -> [String] {
+        var domains = Set<String>()
+        let fm = FileManager.default
+
+        guard let enumerator = fm.enumerator(atPath: directory) else {
+            return []
+        }
+
+        while let relativePath = enumerator.nextObject() as? String {
+            // Skip build directories and hidden files
+            if relativePath.hasPrefix(".") || relativePath.contains("/.") ||
+               relativePath.contains("Pods/") || relativePath.contains(".build/") ||
+               relativePath.contains("DerivedData/") || relativePath.contains("Carthage/") {
+                continue
+            }
+
+            let ext = (relativePath as NSString).pathExtension.lowercased()
+            guard sourceExtensions.contains(ext) else { continue }
+
+            let fullPath = (directory as NSString).appendingPathComponent(relativePath)
+            guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else { continue }
+
+            // Extract domains from URLs
+            let range = NSRange(content.startIndex..., in: content)
+
+            let urlMatches = urlPattern.matches(in: content, options: [], range: range)
+            for match in urlMatches {
+                if let domainRange = Range(match.range(at: 1), in: content) {
+                    let domain = String(content[domainRange]).lowercased()
+                    domains.insert(domain)
+                }
+            }
+
+            // For plist files, also check NSExceptionDomains
+            if ext == "plist" {
+                let plistMatches = plistDomainPattern.matches(in: content, options: [], range: range)
+                for match in plistMatches {
+                    if let domainRange = Range(match.range(at: 1), in: content) {
+                        let domain = String(content[domainRange]).lowercased()
+                        domains.insert(domain)
+                    }
+                }
+            }
+        }
+
+        // Filter out SDK/system domains
+        let filtered = domains.filter { domain in
+            !excludedDomains.contains(where: { domain == $0 || domain.hasSuffix(".\($0)") })
+        }
+
+        return filtered.sorted()
+    }
+}

--- a/Sources/PryLib/RequestBreakpoint.swift
+++ b/Sources/PryLib/RequestBreakpoint.swift
@@ -1,0 +1,102 @@
+import NIO
+import NIOCore
+import NIOHTTP1
+import Foundation
+
+/// Action to take when resuming a paused request
+public enum BreakpointAction {
+    case resume
+    case modify(headers: [(String, String)]?, body: String?)
+    case cancel
+}
+
+/// A request that has been paused at a breakpoint
+public struct PausedRequest {
+    public let id: Int
+    public let method: String
+    public let url: String
+    public let host: String
+    public let headers: [(String, String)]
+    public let body: String?
+    public let timestamp: Date
+
+    let promise: EventLoopPromise<BreakpointAction>
+}
+
+/// Coordinates request pausing and resuming between handlers and TUI
+public class RequestBreakpointManager {
+    public static let shared = RequestBreakpointManager()
+
+    private let queue = DispatchQueue(label: "pry.breakpoint.manager")
+    private var pausedRequests: [PausedRequest] = []
+    public var onPause: (() -> Void)?
+
+    /// Pause a request — returns a future that resolves when the user takes action
+    func pause(
+        id: Int,
+        head: HTTPRequestHead,
+        body: ByteBuffer?,
+        host: String,
+        eventLoop: EventLoop
+    ) -> EventLoopFuture<BreakpointAction> {
+        let promise = eventLoop.makePromise(of: BreakpointAction.self)
+
+        var bodyStr: String?
+        if var buf = body, buf.readableBytes > 0 {
+            bodyStr = buf.readString(length: buf.readableBytes)
+        }
+
+        let paused = PausedRequest(
+            id: id,
+            method: "\(head.method)",
+            url: head.uri,
+            host: host,
+            headers: head.headers.map { ($0.name, $0.value) },
+            body: bodyStr,
+            timestamp: Date(),
+            promise: promise
+        )
+
+        queue.sync {
+            pausedRequests.append(paused)
+        }
+
+        OutputBroker.shared.log(
+            errText("⏸️ BREAKPOINT: \(head.method) \(head.uri) — esperando acción"),
+            type: .info
+        )
+
+        onPause?()
+        return promise.futureResult
+    }
+
+    /// Get all currently paused requests
+    public func getPaused() -> [PausedRequest] {
+        queue.sync { pausedRequests }
+    }
+
+    /// Resume a paused request with an action
+    public func resume(id: Int, action: BreakpointAction) {
+        queue.sync {
+            if let idx = pausedRequests.firstIndex(where: { $0.id == id }) {
+                let paused = pausedRequests.remove(at: idx)
+                paused.promise.succeed(action)
+            }
+        }
+    }
+
+    /// Resume all paused requests
+    public func resumeAll() {
+        queue.sync {
+            for paused in pausedRequests {
+                paused.promise.succeed(.resume)
+            }
+            pausedRequests.removeAll()
+        }
+    }
+
+    /// Count of paused requests
+    public var pausedCount: Int {
+        queue.sync { pausedRequests.count }
+    }
+}

--- a/Sources/PryLib/TUI/RequestStore.swift
+++ b/Sources/PryLib/TUI/RequestStore.swift
@@ -24,13 +24,17 @@ public class RequestStore {
         public var responseBody: String?
         public var isMock: Bool = false
         public var isTunnel: Bool = false
+        public var isPinned: Bool = false
+        public var isWebSocket: Bool = false
+        public var wsFrames: [WSFrame] = []
 
-        public init(id: Int = 0, timestamp: Date = Date(), method: String, url: String, host: String, appIcon: String, appName: String, requestHeaders: [(String, String)] = [], requestBody: String? = nil, statusCode: UInt? = nil, responseHeaders: [(String, String)] = [], responseBody: String? = nil, isMock: Bool = false, isTunnel: Bool = false) {
+        public init(id: Int = 0, timestamp: Date = Date(), method: String, url: String, host: String, appIcon: String, appName: String, requestHeaders: [(String, String)] = [], requestBody: String? = nil, statusCode: UInt? = nil, responseHeaders: [(String, String)] = [], responseBody: String? = nil, isMock: Bool = false, isTunnel: Bool = false, isPinned: Bool = false) {
             self.id = id; self.timestamp = timestamp; self.method = method; self.url = url
             self.host = host; self.appIcon = appIcon; self.appName = appName
             self.requestHeaders = requestHeaders; self.requestBody = requestBody
             self.statusCode = statusCode; self.responseHeaders = responseHeaders
             self.responseBody = responseBody; self.isMock = isMock; self.isTunnel = isTunnel
+            self.isPinned = isPinned
         }
     }
 
@@ -108,6 +112,33 @@ public class RequestStore {
 
     func clear() {
         queue.sync { entries.removeAll() }
+        onChange?()
+    }
+
+    func markWebSocket(id: Int) {
+        queue.sync {
+            if let idx = entries.firstIndex(where: { $0.id == id }) {
+                entries[idx].isWebSocket = true
+            }
+        }
+        onChange?()
+    }
+
+    func addWSFrame(requestId: Int, frame: WSFrame) {
+        queue.sync {
+            if let idx = entries.firstIndex(where: { $0.id == requestId }) {
+                entries[idx].wsFrames.append(frame)
+            }
+        }
+        onChange?()
+    }
+
+    func markPinned(id: Int) {
+        queue.sync {
+            if let idx = entries.firstIndex(where: { $0.id == id }) {
+                entries[idx].isPinned = true
+            }
+        }
         onChange?()
     }
 

--- a/Sources/PryLib/TUI/TUI.swift
+++ b/Sources/PryLib/TUI/TUI.swift
@@ -243,6 +243,9 @@ public class TUI {
                     commandBuffer = "/"
                     renderCommandLine()
                     return
+                case "b":
+                    resumeSelectedBreakpoint()
+                    return
                 default:
                     break
                 }
@@ -309,6 +312,26 @@ public class TUI {
         needsFullRedraw = true
         DispatchQueue.global().async {
             RequestRepeater.repeat_(request: req, proxyPort: self.port)
+        }
+    }
+
+    private func resumeSelectedBreakpoint() {
+        let requests = getFilteredRequests()
+        guard selectedIndex < requests.count else { return }
+        let req = requests[selectedIndex]
+
+        let manager = RequestBreakpointManager.shared
+        let paused = manager.getPaused()
+        if let _ = paused.first(where: { $0.id == req.id }) {
+            manager.resume(id: req.id, action: .resume)
+            statusMessage = "▶ Resumed request \(req.method) \(req.url)"
+        } else {
+            statusMessage = "No breakpoint on this request"
+        }
+        needsFullRedraw = true
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.statusMessage = nil
+            self?.needsFullRedraw = true
         }
     }
 
@@ -484,7 +507,11 @@ public class TUI {
 
                 // Status indicator
                 let statusIcon: String
-                if req.isMock { statusIcon = "🟡" }
+                let isPaused = RequestBreakpointManager.shared.getPaused().contains { $0.id == req.id }
+                if isPaused { statusIcon = "⏸️" }
+                else if req.isPinned { statusIcon = "📌" }
+                else if req.isWebSocket { statusIcon = "🔌" }
+                else if req.isMock { statusIcon = "🟡" }
                 else if req.isTunnel { statusIcon = "🔒" }
                 else if let code = req.statusCode {
                     statusIcon = code < 400 ? "🟢" : "🔴"

--- a/Sources/PryLib/WSFrame.swift
+++ b/Sources/PryLib/WSFrame.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Represents a single WebSocket message frame
+public struct WSFrame {
+    public enum Direction: String {
+        case clientToServer = "↑"
+        case serverToClient = "↓"
+    }
+
+    public enum Opcode: UInt8 {
+        case continuation = 0x0
+        case text = 0x1
+        case binary = 0x2
+        case close = 0x8
+        case ping = 0x9
+        case pong = 0xA
+        case unknown = 0xFF
+
+        public var label: String {
+            switch self {
+            case .continuation: return "continuation"
+            case .text: return "text"
+            case .binary: return "binary"
+            case .close: return "close"
+            case .ping: return "ping"
+            case .pong: return "pong"
+            case .unknown: return "unknown"
+            }
+        }
+    }
+
+    public let timestamp: Date
+    public let direction: Direction
+    public let opcode: Opcode
+    public let payload: Data
+    public let isFinal: Bool
+
+    public var payloadText: String? {
+        String(data: payload, encoding: .utf8)
+    }
+
+    public init(timestamp: Date = Date(), direction: Direction, opcode: Opcode, payload: Data, isFinal: Bool = true) {
+        self.timestamp = timestamp
+        self.direction = direction
+        self.opcode = opcode
+        self.payload = payload
+        self.isFinal = isFinal
+    }
+}

--- a/Sources/PryLib/WebSocketInterceptor.swift
+++ b/Sources/PryLib/WebSocketInterceptor.swift
@@ -1,0 +1,127 @@
+import NIO
+import NIOCore
+import Foundation
+
+/// Intercepts WebSocket frames after upgrade, logs messages bidirectionally.
+/// Sits between TLS/HTTP and GlueHandler to capture WebSocket traffic.
+final class WebSocketInterceptor: ChannelDuplexHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let host: String
+    private let requestId: Int
+    private var clientBuffer = Data()  // client → server (masked)
+    private var serverBuffer = Data()  // server → client (unmasked)
+
+    init(host: String, requestId: Int) {
+        self.host = host
+        self.requestId = requestId
+    }
+
+    // Server → Client
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buffer = unwrapInboundIn(data)
+        if let bytes = buffer.readBytes(length: buffer.readableBytes) {
+            serverBuffer.append(contentsOf: bytes)
+            parseFrames(from: &serverBuffer, direction: .serverToClient)
+        }
+        context.fireChannelRead(data)
+    }
+
+    // Client → Server
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        var buffer = unwrapOutboundIn(data)
+        if let bytes = buffer.getBytes(at: buffer.readerIndex, length: buffer.readableBytes) {
+            clientBuffer.append(contentsOf: bytes)
+            parseFrames(from: &clientBuffer, direction: .clientToServer)
+        }
+        context.write(wrapOutboundOut(buffer), promise: promise)
+    }
+
+    // MARK: - RFC 6455 Frame Parser
+
+    private func parseFrames(from buffer: inout Data, direction: WSFrame.Direction) {
+        while true {
+            guard buffer.count >= 2 else { return }
+
+            let byte0 = buffer[buffer.startIndex]
+            let byte1 = buffer[buffer.startIndex + 1]
+
+            let isFinal = (byte0 & 0x80) != 0
+            let opcodeRaw = byte0 & 0x0F
+            let isMasked = (byte1 & 0x80) != 0
+            var payloadLength = UInt64(byte1 & 0x7F)
+
+            var offset = 2
+
+            // Extended payload length
+            if payloadLength == 126 {
+                guard buffer.count >= offset + 2 else { return }
+                payloadLength = UInt64(buffer[buffer.startIndex + offset]) << 8 |
+                                UInt64(buffer[buffer.startIndex + offset + 1])
+                offset += 2
+            } else if payloadLength == 127 {
+                guard buffer.count >= offset + 8 else { return }
+                payloadLength = 0
+                for i in 0..<8 {
+                    payloadLength = (payloadLength << 8) | UInt64(buffer[buffer.startIndex + offset + i])
+                }
+                offset += 8
+            }
+
+            // Masking key
+            var maskingKey: [UInt8]?
+            if isMasked {
+                guard buffer.count >= offset + 4 else { return }
+                maskingKey = Array(buffer[(buffer.startIndex + offset)..<(buffer.startIndex + offset + 4)])
+                offset += 4
+            }
+
+            // Payload
+            let totalLength = offset + Int(payloadLength)
+            guard buffer.count >= totalLength else { return }
+
+            var payload = Data(buffer[(buffer.startIndex + offset)..<(buffer.startIndex + totalLength)])
+
+            // Unmask if needed
+            if let mask = maskingKey {
+                for i in 0..<payload.count {
+                    payload[payload.startIndex + i] ^= mask[i % 4]
+                }
+            }
+
+            let opcode = WSFrame.Opcode(rawValue: opcodeRaw) ?? .unknown
+            let frame = WSFrame(
+                direction: direction,
+                opcode: opcode,
+                payload: payload,
+                isFinal: isFinal
+            )
+
+            logFrame(frame)
+            RequestStore.shared.addWSFrame(requestId: requestId, frame: frame)
+
+            // Consume parsed bytes
+            buffer.removeFirst(totalLength)
+        }
+    }
+
+    private func logFrame(_ frame: WSFrame) {
+        let dir = frame.direction.rawValue
+        let type = frame.opcode.label
+        let size = frame.payload.count
+
+        let preview: String
+        if let text = frame.payloadText, frame.opcode == .text {
+            let truncated = text.count > 100 ? String(text.prefix(100)) + "..." : text
+            preview = truncated
+        } else {
+            preview = "[\(size) bytes]"
+        }
+
+        let msg = "🔌 WS \(dir) \(host) [\(type)] \(preview)"
+        OutputBroker.shared.log(info(msg), type: .info)
+    }
+}

--- a/Tests/PryLibTests/BreakpointStoreTests.swift
+++ b/Tests/PryLibTests/BreakpointStoreTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import PryLib
+
+final class BreakpointStoreTests: XCTestCase {
+    private var store: BreakpointStore!
+
+    override func setUp() {
+        super.setUp()
+        store = BreakpointStore()
+        store.clearAll()
+    }
+
+    override func tearDown() {
+        store.clearAll()
+        super.tearDown()
+    }
+
+    func testAddAndList() {
+        store.add("/api/login")
+        store.add("/api/users")
+        let patterns = store.all()
+        XCTAssertEqual(patterns.count, 2)
+        XCTAssertTrue(patterns.contains("/api/login"))
+        XCTAssertTrue(patterns.contains("/api/users"))
+    }
+
+    func testNoDuplicates() {
+        store.add("/api/login")
+        store.add("/api/login")
+        XCTAssertEqual(store.all().count, 1)
+    }
+
+    func testRemove() {
+        store.add("/api/login")
+        store.add("/api/users")
+        store.remove("/api/login")
+        let patterns = store.all()
+        XCTAssertEqual(patterns.count, 1)
+        XCTAssertFalse(patterns.contains("/api/login"))
+    }
+
+    func testClearAll() {
+        store.add("/api/login")
+        store.add("/api/users")
+        store.clearAll()
+        XCTAssertTrue(store.all().isEmpty)
+    }
+
+    func testShouldBreakSimplePrefix() {
+        store.add("/api/login")
+        XCTAssertTrue(store.shouldBreak(url: "/api/login", host: "example.com"))
+        XCTAssertFalse(store.shouldBreak(url: "/api/other", host: "example.com"))
+    }
+
+    func testShouldBreakHostMatch() {
+        store.add("api.myapp.com")
+        XCTAssertTrue(store.shouldBreak(url: "/whatever", host: "api.myapp.com"))
+        XCTAssertFalse(store.shouldBreak(url: "/whatever", host: "other.com"))
+    }
+
+    func testShouldBreakGlob() {
+        store.add("*.myapp.com")
+        XCTAssertTrue(store.shouldBreak(url: "/test", host: "api.myapp.com"))
+        XCTAssertTrue(store.shouldBreak(url: "/test", host: "staging.myapp.com"))
+        XCTAssertFalse(store.shouldBreak(url: "/test", host: "other.com"))
+    }
+}

--- a/Tests/PryLibTests/CertificatePinningDetectorTests.swift
+++ b/Tests/PryLibTests/CertificatePinningDetectorTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import PryLib
+
+final class CertificatePinningDetectorTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        RequestStore.shared.clear()
+    }
+
+    override func tearDown() {
+        RequestStore.shared.clear()
+        super.tearDown()
+    }
+
+    func testMarkPinned() {
+        let id = RequestStore.shared.addRequest(
+            method: "CONNECT",
+            url: "secure.bank.com",
+            host: "secure.bank.com",
+            appIcon: "📌",
+            appName: "pinned",
+            headers: [],
+            body: nil
+        )
+        RequestStore.shared.markPinned(id: id)
+
+        let req = RequestStore.shared.get(id: id)
+        XCTAssertNotNil(req)
+        XCTAssertTrue(req!.isPinned)
+    }
+
+    func testNonPinnedRequestDefaultsFalse() {
+        let id = RequestStore.shared.addRequest(
+            method: "GET",
+            url: "/api/test",
+            host: "example.com",
+            appIcon: "🌐",
+            appName: "browser",
+            headers: [],
+            body: nil
+        )
+        let req = RequestStore.shared.get(id: id)
+        XCTAssertNotNil(req)
+        XCTAssertFalse(req!.isPinned)
+    }
+}

--- a/Tests/PryLibTests/ProjectScannerTests.swift
+++ b/Tests/PryLibTests/ProjectScannerTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import PryLib
+
+final class ProjectScannerTests: XCTestCase {
+    private var tempDir: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = NSTemporaryDirectory() + "pry-scanner-test-\(UUID().uuidString)"
+        try! FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: tempDir)
+        super.tearDown()
+    }
+
+    func testFindsURLsInSwiftFiles() {
+        let swift = """
+        let baseURL = "https://api.myapp.com/v1"
+        let staging = "https://staging.myapp.com/v1"
+        """
+        try! swift.write(toFile: tempDir + "/App.swift", atomically: true, encoding: .utf8)
+
+        let domains = ProjectScanner.scan(directory: tempDir)
+        XCTAssertTrue(domains.contains("api.myapp.com"))
+        XCTAssertTrue(domains.contains("staging.myapp.com"))
+    }
+
+    func testExcludesSDKDomains() {
+        let swift = """
+        let api = "https://api.myapp.com/v1"
+        let google = "https://www.googleapis.com/auth"
+        let apple = "https://developer.apple.com"
+        """
+        try! swift.write(toFile: tempDir + "/App.swift", atomically: true, encoding: .utf8)
+
+        let domains = ProjectScanner.scan(directory: tempDir)
+        XCTAssertTrue(domains.contains("api.myapp.com"))
+        XCTAssertFalse(domains.contains("www.googleapis.com"))
+        XCTAssertFalse(domains.contains("developer.apple.com"))
+    }
+
+    func testEmptyDirectoryReturnsEmpty() {
+        let domains = ProjectScanner.scan(directory: tempDir)
+        XCTAssertTrue(domains.isEmpty)
+    }
+
+    func testSkipsBuildDirectories() {
+        let buildDir = tempDir + "/.build/debug"
+        try! FileManager.default.createDirectory(atPath: buildDir, withIntermediateDirectories: true)
+        let swift = """
+        let url = "https://should.not.find.com/api"
+        """
+        try! swift.write(toFile: buildDir + "/Generated.swift", atomically: true, encoding: .utf8)
+
+        let domains = ProjectScanner.scan(directory: tempDir)
+        XCTAssertFalse(domains.contains("should.not.find.com"))
+    }
+
+    func testResultsAreSorted() {
+        let swift = """
+        let z = "https://zebra.api.com"
+        let a = "https://alpha.api.com"
+        let m = "https://mid.api.com"
+        """
+        try! swift.write(toFile: tempDir + "/App.swift", atomically: true, encoding: .utf8)
+
+        let domains = ProjectScanner.scan(directory: tempDir)
+        XCTAssertEqual(domains, domains.sorted())
+    }
+}

--- a/Tests/PryLibTests/ProxyErrorTests.swift
+++ b/Tests/PryLibTests/ProxyErrorTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import PryLib
+
+final class ProxyErrorTests: XCTestCase {
+    func testAlreadyRunningDescription() {
+        let err = ProxyError.alreadyRunning
+        XCTAssertEqual(err.description, "Proxy is already running")
+    }
+
+    func testNotRunningDescription() {
+        let err = ProxyError.notRunning
+        XCTAssertEqual(err.description, "Proxy is not running")
+    }
+
+    func testInvalidPortDescription() {
+        let err = ProxyError.invalidPort("abc")
+        XCTAssertTrue(err.description.contains("abc"))
+    }
+
+    func testMockFileNotFoundDescription() {
+        let err = ProxyError.mockFileNotFound("/tmp/nope.json")
+        XCTAssertTrue(err.description.contains("/tmp/nope.json"))
+    }
+
+    func testInvalidJSONDescription() {
+        let err = ProxyError.invalidJSON("unexpected token")
+        XCTAssertTrue(err.description.contains("unexpected token"))
+    }
+
+    func testConnectionFailedDescription() {
+        let err = ProxyError.connectionFailed("example.com")
+        XCTAssertTrue(err.description.contains("example.com"))
+    }
+
+    func testConformsToError() {
+        let err: Error = ProxyError.alreadyRunning
+        XCTAssertFalse(err.localizedDescription.isEmpty)
+    }
+}

--- a/Tests/PryLibTests/WSFrameTests.swift
+++ b/Tests/PryLibTests/WSFrameTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import PryLib
+
+final class WSFrameTests: XCTestCase {
+    func testTextFramePayload() {
+        let frame = WSFrame(
+            direction: .clientToServer,
+            opcode: .text,
+            payload: "hello".data(using: .utf8)!
+        )
+        XCTAssertEqual(frame.payloadText, "hello")
+        XCTAssertEqual(frame.direction.rawValue, "↑")
+        XCTAssertEqual(frame.opcode.label, "text")
+        XCTAssertTrue(frame.isFinal)
+    }
+
+    func testBinaryFramePayload() {
+        let data = Data([0x00, 0x01, 0x02, 0xFF])
+        let frame = WSFrame(
+            direction: .serverToClient,
+            opcode: .binary,
+            payload: data
+        )
+        XCTAssertEqual(frame.payload, data)
+        XCTAssertEqual(frame.direction.rawValue, "↓")
+        XCTAssertEqual(frame.opcode.label, "binary")
+    }
+
+    func testControlFrameLabels() {
+        XCTAssertEqual(WSFrame.Opcode.close.label, "close")
+        XCTAssertEqual(WSFrame.Opcode.ping.label, "ping")
+        XCTAssertEqual(WSFrame.Opcode.pong.label, "pong")
+        XCTAssertEqual(WSFrame.Opcode.continuation.label, "continuation")
+        XCTAssertEqual(WSFrame.Opcode.unknown.label, "unknown")
+    }
+
+    func testOpcodeFromRawValue() {
+        XCTAssertEqual(WSFrame.Opcode(rawValue: 0x1), .text)
+        XCTAssertEqual(WSFrame.Opcode(rawValue: 0x2), .binary)
+        XCTAssertEqual(WSFrame.Opcode(rawValue: 0x8), .close)
+        XCTAssertEqual(WSFrame.Opcode(rawValue: 0x9), .ping)
+        XCTAssertEqual(WSFrame.Opcode(rawValue: 0xA), .pong)
+        XCTAssertNil(WSFrame.Opcode(rawValue: 0x3))
+    }
+
+    func testWebSocketRequestStore() {
+        let store = RequestStore.shared
+        store.clear()
+
+        let id = store.addRequest(
+            method: "GET",
+            url: "/ws",
+            host: "echo.websocket.org",
+            appIcon: "🔌",
+            appName: "ws",
+            headers: [],
+            body: nil
+        )
+        store.markWebSocket(id: id)
+
+        let frame = WSFrame(direction: .clientToServer, opcode: .text, payload: "test".data(using: .utf8)!)
+        store.addWSFrame(requestId: id, frame: frame)
+
+        let req = store.get(id: id)
+        XCTAssertNotNil(req)
+        XCTAssertTrue(req!.isWebSocket)
+        XCTAssertEqual(req!.wsFrames.count, 1)
+        XCTAssertEqual(req!.wsFrames[0].payloadText, "test")
+
+        store.clear()
+    }
+}


### PR DESCRIPTION
## Summary
- **Certificate pinning detection**: heuristic detector monitors client behavior after MITM TLS handshake, logs with 📌 icon
- **`pry init`**: scans project directories for API domains in `.swift`/`.plist` files, auto-generates `.prywatch`
- **WebSocket interception**: RFC 6455 frame parser with bidirectional logging, 🔌 icon in TUI
- **Breakpoints**: `pry break PATTERN` pauses requests via `EventLoopPromise`, resume with `b` in TUI, ⏸️ indicator
- **Homebrew formula**: `Formula/pry.rb` for `brew install`
- **Docs**: README with TUI keybindings, updated ROADMAP reflecting actual state
- **CI**: `swift test` added to macOS and Linux jobs

## Test plan
- [x] `swift build` compiles without errors
- [x] `swift test` — 58 tests, 0 failures
- [ ] CI passes on GitHub Actions (macOS-14 + Linux)
- [ ] Manual: `pry init` on an iOS project generates correct `.prywatch`
- [ ] Manual: `pry break /api/test` + send request → pauses in TUI, `b` resumes
- [ ] Manual: WebSocket upgrade detection with `wss://` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)