### PR TITLE
feat: PryApp Day 4 — Settings + Distribution

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,73 @@
+name: Release App
+
+on:
+  push:
+    tags: ["app-v*"]
+
+jobs:
+  build-dmg:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#app-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/repositories
+            .build/checkouts
+            .build/artifacts
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      - name: Build App Bundle
+        run: |
+          chmod +x scripts/build-app.sh
+          ./scripts/build-app.sh "${{ steps.version.outputs.version }}"
+
+      - name: Package DMG
+        run: |
+          chmod +x scripts/package-dmg.sh
+          ./scripts/package-dmg.sh "${{ steps.version.outputs.version }}"
+
+      - name: Generate checksums
+        run: |
+          cd build
+          shasum -a 256 Pry-*.dmg > checksums-app.txt
+          cat checksums-app.txt
+
+      # TODO: Code signing + notarization steps
+      # Requires APPLE_DEVELOPER_ID_CERT, APPLE_ID, TEAM_ID, APP_PASSWORD secrets
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Pry App v${{ steps.version.outputs.version }}"
+          body: |
+            ## Pry App v${{ steps.version.outputs.version }}
+
+            ### Installation
+
+            **DMG (drag to Applications):**
+            ```
+            Download Pry-${{ steps.version.outputs.version }}.dmg below
+            ```
+
+            **Homebrew Cask:**
+            ```bash
+            brew tap fsaldivar-dev/pry
+            brew install --cask pry-app
+            ```
+
+            ### Requirements
+            - macOS 14 (Sonoma) or later
+
+            > ⚠️ This release is not code-signed or notarized yet.
+            > You may need to right-click → Open on first launch.
+          files: |
+            build/Pry-*.dmg
+            build/checksums-app.txt

--- a/Casks/pry-app.rb
+++ b/Casks/pry-app.rb
@@ -1,0 +1,21 @@
+cask "pry-app" do
+  version "1.0.0"
+  sha256 "PLACEHOLDER"
+
+  url "https://github.com/fsaldivar-dev/pry/releases/download/v#{version}/Pry-#{version}.dmg"
+  name "Pry"
+  desc "macOS HTTP/HTTPS debugging proxy with GUI"
+  homepage "https://github.com/fsaldivar-dev/pry"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Pry.app"
+  binary "#{appdir}/Pry.app/Contents/MacOS/pry"
+
+  zap trash: [
+    "~/.pry",
+    "~/.prywatch",
+    "~/.pryconfig",
+    "/tmp/pry.*",
+  ]
+end

--- a/Sources/PryApp/PryApp.swift
+++ b/Sources/PryApp/PryApp.swift
@@ -20,6 +20,11 @@ struct PryApp: App {
         }
         .defaultSize(width: 1200, height: 800)
 
+        Settings {
+            SettingsView()
+                .environment(proxyManager)
+        }
+
         MenuBarExtra("Pry", systemImage: "cat.fill") {
             PryMenuBarContent()
                 .environment(proxyManager)

--- a/Sources/PryApp/Views/JSONSyntaxView.swift
+++ b/Sources/PryApp/Views/JSONSyntaxView.swift
@@ -54,7 +54,7 @@ struct JSONSyntaxView: View {
     }
 
     // Compiled once, reused for every line — avoids O(n) regex compilations
-    private static let keyValueRegex: NSRegularExpression = {
+    private nonisolated(unsafe) static let keyValueRegex: NSRegularExpression = {
         try! NSRegularExpression(pattern: #"^(\s*)"([^"]+)"(\s*:\s*)(.*)"#)
     }()
 

--- a/Sources/PryApp/Views/Settings/AppearanceView.swift
+++ b/Sources/PryApp/Views/Settings/AppearanceView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+@available(macOS 14, *)
+struct AppearanceView: View {
+    @AppStorage("pry.fontSize") private var fontSize: Double = 11
+    @AppStorage("pry.monoFont") private var useMonoFont = true
+    @AppStorage("pry.colorScheme") private var colorSchemePreference = "system"
+
+    var body: some View {
+        Form {
+            Section("Font") {
+                HStack {
+                    Text("Font Size")
+                    Slider(value: $fontSize, in: 9...16, step: 1)
+                    Text("\(Int(fontSize))pt")
+                        .frame(width: 40)
+                        .monospacedDigit()
+                }
+
+                Toggle("Use monospaced font for code", isOn: $useMonoFont)
+
+                Text("Preview:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("GET /api/users → 200 OK")
+                    .font(.system(size: CGFloat(fontSize), design: useMonoFont ? .monospaced : .default))
+                    .padding(8)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+
+            Section("Theme") {
+                Picker("Color Scheme", selection: $colorSchemePreference) {
+                    Text("System").tag("system")
+                    Text("Light").tag("light")
+                    Text("Dark").tag("dark")
+                }
+                .pickerStyle(.segmented)
+
+                Text("Changes take effect immediately")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("About") {
+                LabeledContent("Version", value: "1.0.0")
+                LabeledContent("Engine", value: "PryLib + SwiftNIO")
+
+                Link("GitHub Repository",
+                     destination: URL(string: "https://github.com/fsaldivar-dev/pry")!)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}

--- a/Sources/PryApp/Views/Settings/CertificateView.swift
+++ b/Sources/PryApp/Views/Settings/CertificateView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import PryLib
+
+@available(macOS 14, *)
+@MainActor
+struct CertificateView: View {
+    @State private var caExists = false
+    @State private var trustStatus = "Checking..."
+    @State private var isCheckingTrust = false
+
+    var body: some View {
+        Form {
+            Section("Pry Certificate Authority") {
+                LabeledContent("CA Directory") {
+                    Text(CertificateAuthority.caDir)
+                        .font(.system(size: 11, design: .monospaced))
+                        .textSelection(.enabled)
+                        .foregroundStyle(.secondary)
+                }
+
+                LabeledContent("Certificate") {
+                    if caExists {
+                        Label("Generated", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        Label("Not Generated", systemImage: "xmark.circle")
+                            .foregroundStyle(.orange)
+                    }
+                }
+
+                LabeledContent("Keychain Trust") {
+                    Text(trustStatus)
+                        .foregroundStyle(trustStatus == "Trusted" ? .green : .secondary)
+                }
+            }
+
+            Section("Actions") {
+                if caExists {
+                    Button("Reveal in Finder") {
+                        NSWorkspace.shared.selectFile(
+                            CertificateAuthority.caCertPath,
+                            inFileViewerRootedAtPath: CertificateAuthority.caDir
+                        )
+                    }
+
+                    Button("Copy Certificate Path") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(CertificateAuthority.caCertPath, forType: .string)
+                    }
+                } else {
+                    Text("Start the proxy to generate the CA certificate.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Instructions") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("For HTTPS interception, the CA must be trusted:")
+                        .font(.caption)
+                    Text("1. Open Keychain Access")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Text("2. Drag the pry-ca.pem file into the System keychain")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Text("3. Double-click the certificate → Trust → Always Trust")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Text("")
+                    Text("For iOS Simulator: run `pry trust` in Terminal")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear { checkCA() }
+    }
+
+    private func checkCA() {
+        caExists = FileManager.default.fileExists(atPath: CertificateAuthority.caCertPath)
+        if caExists {
+            checkTrustStatus()
+        } else {
+            trustStatus = "N/A — certificate not generated"
+        }
+    }
+
+    private func checkTrustStatus() {
+        // Check if CA is in the trusted certs via security CLI
+        Task.detached {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+            process.arguments = ["verify-cert", "-c", CertificateAuthority.caCertPath]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+            try? process.run()
+            process.waitUntilExit()
+            let status = process.terminationStatus == 0 ? "Trusted" : "Not Trusted"
+            await MainActor.run {
+                trustStatus = status
+            }
+        }
+    }
+}

--- a/Sources/PryApp/Views/Settings/DomainListView.swift
+++ b/Sources/PryApp/Views/Settings/DomainListView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import PryKit
+import PryLib
+
+@available(macOS 14, *)
+@MainActor
+struct DomainListView: View {
+    @Environment(ProxyManager.self) private var proxy
+    @State private var newDomain = ""
+    @State private var showingScanner = false
+    @State private var scannedDomains: [String] = []
+    @State private var showScannedSheet = false
+
+    var body: some View {
+        Form {
+            Section("Intercepted Domains") {
+                if proxy.domains.isEmpty {
+                    Text("No domains in watchlist")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    List {
+                        ForEach(proxy.domains, id: \.self) { domain in
+                            HStack {
+                                Image(systemName: "globe")
+                                    .foregroundStyle(.secondary)
+                                Text(domain)
+                                    .font(.system(size: 12, design: .monospaced))
+                                Spacer()
+                                Button {
+                                    proxy.removeDomain(domain)
+                                } label: {
+                                    Image(systemName: "xmark.circle")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.borderless)
+                            }
+                        }
+                    }
+                    .frame(minHeight: 120)
+                }
+
+                HStack {
+                    TextField("Add domain", text: $newDomain, prompt: Text("api.example.com"))
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { addDomain() }
+                    Button("Add") { addDomain() }
+                        .disabled(newDomain.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+
+            Section("Auto-discover") {
+                HStack {
+                    Button("Scan Project...") { showingScanner = true }
+                    Text("Find domains in your source code")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .fileImporter(
+                    isPresented: $showingScanner,
+                    allowedContentTypes: [.folder]
+                ) { result in
+                    if case .success(let url) = result {
+                        let discovered = ProjectScanner.scan(directory: url.path)
+                        if discovered.isEmpty {
+                            scannedDomains = []
+                        } else {
+                            scannedDomains = discovered.filter { !proxy.domains.contains($0) }
+                        }
+                        showScannedSheet = true
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .sheet(isPresented: $showScannedSheet) {
+            ScannedDomainsSheet(domains: scannedDomains) { selected in
+                for domain in selected {
+                    proxy.addDomain(domain)
+                }
+            }
+        }
+    }
+
+    private func addDomain() {
+        let domain = newDomain.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !domain.isEmpty else { return }
+        proxy.addDomain(domain)
+        newDomain = ""
+    }
+}
+
+@available(macOS 14, *)
+private struct ScannedDomainsSheet: View {
+    let domains: [String]
+    let onAdd: ([String]) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var selected: Set<String> = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Discovered Domains")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Add Selected") {
+                    onAdd(Array(selected))
+                    dismiss()
+                }
+                .disabled(selected.isEmpty)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+
+            Divider()
+
+            if domains.isEmpty {
+                ContentUnavailableView(
+                    "No Domains Found",
+                    systemImage: "magnifyingglass",
+                    description: Text("No new domains were found in the project")
+                )
+            } else {
+                List(domains, id: \.self, selection: $selected) { domain in
+                    Text(domain)
+                        .font(.system(size: 12, design: .monospaced))
+                }
+            }
+        }
+        .frame(minWidth: 400, minHeight: 300)
+        .onAppear { selected = Set(domains) }
+    }
+}

--- a/Sources/PryApp/Views/Settings/ProxySettingsView.swift
+++ b/Sources/PryApp/Views/Settings/ProxySettingsView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import PryKit
+import PryLib
+
+@available(macOS 14, *)
+@MainActor
+struct ProxySettingsView: View {
+    @Environment(ProxyManager.self) private var proxy
+    @State private var portText: String = ""
+    @State private var portError: String?
+    @AppStorage("pry.autoStart") private var autoStart = false
+
+    var body: some View {
+        Form {
+            Section("Proxy Server") {
+                LabeledContent("Status") {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(proxy.isRunning ? .green : .red)
+                            .frame(width: 8, height: 8)
+                        Text(proxy.isRunning ? "Running" : "Stopped")
+                    }
+                }
+
+                HStack {
+                    LabeledContent("Port") {
+                        TextField("8080", text: $portText)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 80)
+                            .onChange(of: portText) { validatePort() }
+                    }
+                    if let portError {
+                        Text(portError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Button("Apply Port") {
+                    applyPort()
+                }
+                .disabled(portError != nil || portText.isEmpty)
+            }
+
+            Section("Startup") {
+                Toggle("Auto-start proxy on launch", isOn: $autoStart)
+                Text("Proxy will start automatically when PryApp opens")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Network") {
+                LabeledContent("Proxy URL") {
+                    Text("http://localhost:\(proxy.port)")
+                        .font(.system(size: 12, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+
+                Button("Copy Proxy URL") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString("http://localhost:\(proxy.port)", forType: .string)
+                }
+
+                Text("Configure your app or browser to use this proxy address.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear {
+            portText = "\(proxy.port)"
+        }
+    }
+
+    private func validatePort() {
+        guard let port = Int(portText) else {
+            portError = "Must be a number"
+            return
+        }
+        guard port >= 1024, port <= 65535 else {
+            portError = "Must be 1024–65535"
+            return
+        }
+        portError = nil
+    }
+
+    private func applyPort() {
+        guard let port = Int(portText), portError == nil else { return }
+        Config.set("port", value: "\(port)")
+        proxy.port = port
+    }
+}

--- a/Sources/PryApp/Views/Settings/RulesSettingsView.swift
+++ b/Sources/PryApp/Views/Settings/RulesSettingsView.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+import PryLib
+
+@available(macOS 14, *)
+@MainActor
+struct RulesSettingsView: View {
+    @State private var headerRules: [HeaderRewrite.Rule] = []
+    @State private var mapLocalRules: [MapLocal.MapRule] = []
+    @State private var mapRemoteRules: [MapRemote.RedirectRule] = []
+
+    // New rule fields
+    @State private var newHeaderName = ""
+    @State private var newHeaderValue = ""
+    @State private var newMapRegex = ""
+    @State private var newMapFile = ""
+    @State private var newRedirectSrc = ""
+    @State private var newRedirectDst = ""
+
+    // Validation errors
+    @State private var regexError: String?
+    @State private var fileError: String?
+    @State private var hostError: String?
+
+    var body: some View {
+        Form {
+            Section("Header Rewrite Rules") {
+                if headerRules.isEmpty {
+                    Text("No header rules").font(.caption).foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(headerRules.enumerated()), id: \.offset) { _, rule in
+                        HStack {
+                            Text(rule.name)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(.blue)
+                            Text(rule.value ?? "")
+                                .font(.system(size: 11, design: .monospaced))
+                            Spacer()
+                            Button {
+                                HeaderRewrite.removeRule(name: rule.name)
+                                reload()
+                            } label: {
+                                Image(systemName: "xmark.circle").foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                }
+                HStack {
+                    TextField("Header", text: $newHeaderName)
+                        .textFieldStyle(.roundedBorder).frame(maxWidth: 150)
+                    TextField("Value", text: $newHeaderValue)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Add") {
+                        let name = newHeaderName.trimmingCharacters(in: .whitespaces)
+                        guard !name.isEmpty, Self.isValidHeaderName(name) else { return }
+                        HeaderRewrite.addRule(name: name, value: newHeaderValue)
+                        newHeaderName = ""; newHeaderValue = ""
+                        reload()
+                    }
+                    .disabled(newHeaderName.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+
+            Section("Map Local (URL → File)") {
+                if mapLocalRules.isEmpty {
+                    Text("No map local rules").font(.caption).foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(mapLocalRules.enumerated()), id: \.offset) { _, rule in
+                        VStack(alignment: .leading) {
+                            Text(rule.regex).font(.system(size: 11, design: .monospaced))
+                            Text("→ \(rule.filePath)")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                VStack(alignment: .leading) {
+                    HStack {
+                        TextField("URL regex", text: $newMapRegex)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: newMapRegex) { validateRegex() }
+                        TextField("File path", text: $newMapFile)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: newMapFile) { validateFilePath() }
+                        Button("Add") {
+                            guard validateMapLocalInputs() else { return }
+                            MapLocal.save(regex: newMapRegex, filePath: newMapFile)
+                            newMapRegex = ""; newMapFile = ""
+                            regexError = nil; fileError = nil
+                            reload()
+                        }
+                        .disabled(newMapRegex.isEmpty || newMapFile.isEmpty ||
+                                  regexError != nil || fileError != nil)
+                    }
+                    if let regexError {
+                        Text(regexError).font(.caption2).foregroundStyle(.red)
+                    }
+                    if let fileError {
+                        Text(fileError).font(.caption2).foregroundStyle(.red)
+                    }
+                }
+            }
+
+            Section("Map Remote (Host → Host)") {
+                if mapRemoteRules.isEmpty {
+                    Text("No redirect rules").font(.caption).foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(mapRemoteRules.enumerated()), id: \.offset) { _, rule in
+                        HStack {
+                            Text(rule.sourceHost)
+                                .font(.system(size: 11, design: .monospaced))
+                            Image(systemName: "arrow.right")
+                                .foregroundStyle(.secondary)
+                            Text(rule.targetHost)
+                                .font(.system(size: 11, design: .monospaced))
+                        }
+                    }
+                }
+                VStack(alignment: .leading) {
+                    HStack {
+                        TextField("Source host", text: $newRedirectSrc)
+                            .textFieldStyle(.roundedBorder)
+                        TextField("Target host", text: $newRedirectDst)
+                            .textFieldStyle(.roundedBorder)
+                        Button("Add") {
+                            let src = newRedirectSrc.trimmingCharacters(in: .whitespaces).lowercased()
+                            let dst = newRedirectDst.trimmingCharacters(in: .whitespaces).lowercased()
+                            guard Self.isValidHostname(src), Self.isValidHostname(dst) else {
+                                hostError = "Invalid hostname format"
+                                return
+                            }
+                            MapRemote.save(sourceHost: src, targetHost: dst)
+                            newRedirectSrc = ""; newRedirectDst = ""
+                            hostError = nil
+                            reload()
+                        }
+                        .disabled(newRedirectSrc.isEmpty || newRedirectDst.isEmpty)
+                    }
+                    if let hostError {
+                        Text(hostError).font(.caption2).foregroundStyle(.red)
+                    }
+                }
+            }
+
+            Section {
+                Button("Clear All Rules", role: .destructive) {
+                    HeaderRewrite.clear()
+                    MapLocal.clear()
+                    MapRemote.clear()
+                    reload()
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear { reload() }
+    }
+
+    private func reload() {
+        headerRules = HeaderRewrite.loadAll()
+        mapLocalRules = MapLocal.loadAll()
+        mapRemoteRules = MapRemote.loadAll()
+    }
+
+    // MARK: - Input Validation
+
+    /// Validate HTTP header name: alphanumeric + hyphens only (RFC 7230)
+    private static func isValidHeaderName(_ name: String) -> Bool {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        return !name.isEmpty && name.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+
+    /// Validate regex compiles without error
+    private func validateRegex() {
+        let pattern = newMapRegex.trimmingCharacters(in: .whitespaces)
+        guard !pattern.isEmpty else { regexError = nil; return }
+        do {
+            _ = try NSRegularExpression(pattern: pattern)
+            regexError = nil
+        } catch {
+            regexError = "Invalid regex: \(error.localizedDescription)"
+        }
+    }
+
+    /// Validate file path: must be absolute, no traversal, file must exist
+    private func validateFilePath() {
+        let path = newMapFile.trimmingCharacters(in: .whitespaces)
+        guard !path.isEmpty else { fileError = nil; return }
+        // Must be absolute path
+        guard path.hasPrefix("/") else {
+            fileError = "Must be an absolute path (starting with /)"
+            return
+        }
+        // Reject path traversal
+        let resolved = (path as NSString).standardizingPath
+        guard !resolved.contains("..") else {
+            fileError = "Path traversal not allowed"
+            return
+        }
+        // File must exist
+        guard FileManager.default.fileExists(atPath: resolved) else {
+            fileError = "File does not exist"
+            return
+        }
+        fileError = nil
+    }
+
+    /// Combined validation for Map Local inputs
+    private func validateMapLocalInputs() -> Bool {
+        validateRegex()
+        validateFilePath()
+        return regexError == nil && fileError == nil
+    }
+
+    /// Validate hostname: alphanumeric, dots, hyphens, optional port
+    private static func isValidHostname(_ host: String) -> Bool {
+        // hostname:port or hostname
+        let parts = host.split(separator: ":", maxSplits: 1)
+        let hostname = String(parts[0])
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: ".-*"))
+        guard !hostname.isEmpty,
+              hostname.unicodeScalars.allSatisfy({ allowed.contains($0) }),
+              !hostname.contains("..") else { return false }
+        // Validate port if present
+        if parts.count == 2 {
+            guard let port = Int(parts[1]), port > 0, port <= 65535 else { return false }
+        }
+        return true
+    }
+}

--- a/Sources/PryApp/Views/Settings/SettingsView.swift
+++ b/Sources/PryApp/Views/Settings/SettingsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@available(macOS 14, *)
+@MainActor
+struct SettingsView: View {
+    var body: some View {
+        TabView {
+            DomainListView()
+                .tabItem { Label("Domains", systemImage: "globe") }
+            CertificateView()
+                .tabItem { Label("Certificate", systemImage: "lock.shield") }
+            ProxySettingsView()
+                .tabItem { Label("Proxy", systemImage: "network") }
+            RulesSettingsView()
+                .tabItem { Label("Rules", systemImage: "list.bullet.rectangle") }
+            AppearanceView()
+                .tabItem { Label("Appearance", systemImage: "paintbrush") }
+        }
+        .frame(width: 550, height: 420)
+    }
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Build PryApp as a macOS .app bundle
+# Usage: ./scripts/build-app.sh [VERSION]
+
+set -euo pipefail
+
+VERSION="${1:-1.0.0}"
+APP_NAME="Pry"
+BUILD_DIR="build/app"
+APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+
+echo "==> Building PryApp v${VERSION}..."
+
+# Clean
+rm -rf "${BUILD_DIR}"
+mkdir -p "${APP_BUNDLE}/Contents/MacOS"
+mkdir -p "${APP_BUNDLE}/Contents/Resources"
+
+# Build release binaries
+swift build -c release
+
+# SPM puts executables in arch-specific path
+BIN_PATH="$(swift build -c release --show-bin-path)"
+
+# Validate binaries exist before copying
+if [ ! -f "${BIN_PATH}/PryApp" ]; then
+    echo "ERROR: PryApp binary not found at ${BIN_PATH}/PryApp"
+    exit 1
+fi
+if [ ! -f "${BIN_PATH}/pry" ]; then
+    echo "ERROR: pry CLI binary not found at ${BIN_PATH}/pry"
+    exit 1
+fi
+
+# Copy app binary
+cp "${BIN_PATH}/PryApp" "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
+
+# Also include CLI binary
+cp "${BIN_PATH}/pry" "${APP_BUNDLE}/Contents/MacOS/pry"
+
+# Create Info.plist
+cat > "${APP_BUNDLE}/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleDisplayName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.fsaldivar.pry</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundleExecutable</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticTermination</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.developer-tools</string>
+</dict>
+</plist>
+PLIST
+
+echo "==> App bundle created: ${APP_BUNDLE}"
+echo "    Binary: $(file "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}")"
+echo "    Size: $(du -sh "${APP_BUNDLE}" | cut -f1)"

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Package PryApp.app into a DMG
+# Usage: ./scripts/package-dmg.sh [VERSION]
+# Requires: build-app.sh to have been run first
+
+set -euo pipefail
+
+VERSION="${1:-1.0.0}"
+APP_NAME="Pry"
+BUILD_DIR="build/app"
+APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+DMG_DIR="build/dmg"
+DMG_NAME="Pry-${VERSION}.dmg"
+DMG_PATH="build/${DMG_NAME}"
+VOL_NAME="${APP_NAME} ${VERSION}"
+
+if [ ! -d "${APP_BUNDLE}" ]; then
+    echo "ERROR: ${APP_BUNDLE} not found. Run build-app.sh first."
+    exit 1
+fi
+
+echo "==> Packaging DMG: ${DMG_NAME}..."
+
+# Prepare DMG staging directory
+rm -rf "${DMG_DIR}"
+mkdir -p "${DMG_DIR}"
+cp -R "${APP_BUNDLE}" "${DMG_DIR}/"
+
+# Create Applications symlink for drag-to-install
+ln -s /Applications "${DMG_DIR}/Applications"
+
+# Create DMG using hdiutil (no external deps needed)
+rm -f "${DMG_PATH}"
+hdiutil create \
+    -volname "${VOL_NAME}" \
+    -srcfolder "${DMG_DIR}" \
+    -ov \
+    -format UDZO \
+    "${DMG_PATH}"
+
+# Cleanup staging
+rm -rf "${DMG_DIR}"
+
+echo "==> DMG created: ${DMG_PATH}"
+echo "    Size: $(du -sh "${DMG_PATH}" | cut -f1)"
+echo ""
+echo "SHA256: $(shasum -a 256 "${DMG_PATH}" | cut -d' ' -f1)"
+
+# TODO: Code signing (requires Apple Developer ID certificate)
+# codesign --deep --force --options runtime \
+#   --sign "Developer ID Application: YOUR_NAME (TEAM_ID)" \
+#   "${APP_BUNDLE}"
+
+# TODO: Notarization (requires Apple Developer account)
+# xcrun notarytool submit "${DMG_PATH}" \
+#   --apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APP_PASSWORD" \
+#   --wait


### PR DESCRIPTION
## Summary
- **#44 SettingsView**: 5-tab Settings window (Cmd+,) — Domains (CRUD + project scan), Certificate (CA status + trust check), Proxy (port + auto-start), Rules (HeaderRewrite + MapLocal + MapRemote with input validation), Appearance (font + theme)
- **#45 Distribution**: `build-app.sh` (SPM → .app bundle), `package-dmg.sh` (hdiutil DMG), `release-app.yml` (CI on `app-v*` tags), Homebrew Cask formula
- **Fix**: JSONSyntaxView `nonisolated(unsafe)` regex warning

### Verified locally
- `.app` bundle: 16MB arm64 Mach-O with Info.plist + CLI binary
- `.dmg`: 5.4MB compressed, Applications symlink, drag-to-install

Closes #44, #45

## Test plan
- [x] `swift build` — compiles without warnings
- [x] `swift test` — 138 tests pass (0 failures)
- [x] `bash scripts/build-app.sh 1.0.0` — generates Pry.app bundle
- [x] `bash scripts/package-dmg.sh 1.0.0` — generates 5.4MB DMG
- [ ] Open PryApp → Cmd+, → Settings with 5 tabs
- [ ] Settings > Domains: add/remove domain
- [ ] Settings > Certificate: shows CA path and trust status
- [ ] Settings > Rules: add header rewrite rule with validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)