### PR TITLE
feat: XcodeGen project + app resources for PryApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .build/
 .swiftpm/
 *.xcodeproj
+*.xcworkspace
 DerivedData/
+build/
 .prywatch
 .pryconfig
 /tmp/pry.*

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,9 @@ targets += [
     .executableTarget(
         name: "PryApp",
         dependencies: ["PryKit"],
-        path: "Sources/PryApp"
+        path: "Sources/PryApp",
+        exclude: ["Resources/Info.plist", "Resources/PryApp.entitlements"],
+        resources: [.process("Resources/Assets.xcassets")]
     ),
     .testTarget(
         name: "PryKitTests",

--- a/Sources/PryApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sources/PryApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/PryApp/Resources/Assets.xcassets/Contents.json
+++ b/Sources/PryApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/PryApp/Resources/Info.plist
+++ b/Sources/PryApp/Resources/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Pry</string>
+    <key>CFBundleDisplayName</key>
+    <string>Pry</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleIconFile</key>
+    <string></string>
+    <key>CFBundleIconName</key>
+    <string>AppIcon</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticTermination</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.developer-tools</string>
+    <key>NSMainStoryboardFile</key>
+    <string></string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/Sources/PryApp/Resources/PryApp.entitlements
+++ b/Sources/PryApp/Resources/PryApp.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        App Sandbox DISABLED — required for HTTP proxy functionality:
+        - ProxyServer binds to localhost ports (8080+) via SwiftNIO
+        - CertificateAuthority reads/writes ~/.pry/ca/ for TLS interception
+        - Config files (.prywatch, .pryconfig, .pryrules) in user's CWD
+        - Future: networksetup for system proxy auto-enable (#25)
+        Same pattern as Charles Proxy, Proxyman, mitmproxy.
+    -->
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,40 @@
+name: Pry
+options:
+  bundleIdPrefix: dev.fsaldivar
+  deploymentTarget:
+    macOS: "14.0"
+  xcodeVersion: "15.0"
+  createIntermediateGroups: true
+
+packages:
+  pry:
+    path: .
+
+targets:
+  PryApp:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/PryApp
+        excludes:
+          - "Resources/Info.plist"
+    resources:
+      - path: Sources/PryApp/Resources/Assets.xcassets
+    dependencies:
+      - package: pry
+        product: PryKit
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: dev.fsaldivar.pry
+        PRODUCT_NAME: Pry
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: 1
+        INFOPLIST_FILE: Sources/PryApp/Resources/Info.plist
+        CODE_SIGN_ENTITLEMENTS: Sources/PryApp/Resources/PryApp.entitlements
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_IDENTITY: "-"
+        SWIFT_VERSION: "5.9"
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        GENERATE_INFOPLIST_FILE: false
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        COMBINE_HIDPI_IMAGES: true

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -7,7 +7,14 @@ set -euo pipefail
 VERSION="${1:-1.0.0}"
 APP_NAME="Pry"
 BUILD_DIR="build/app"
+
+# Validate VERSION is a semver string (no injection via sed)
+if ! echo "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    echo "ERROR: Invalid version '${VERSION}'. Must be semver (e.g. 1.0.0)"
+    exit 1
+fi
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+RESOURCES_DIR="Sources/PryApp/Resources"
 
 echo "==> Building PryApp v${VERSION}..."
 
@@ -32,47 +39,25 @@ if [ ! -f "${BIN_PATH}/pry" ]; then
     exit 1
 fi
 
-# Copy app binary
+# Copy binaries
 cp "${BIN_PATH}/PryApp" "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}"
-
-# Also include CLI binary
 cp "${BIN_PATH}/pry" "${APP_BUNDLE}/Contents/MacOS/pry"
 
-# Create Info.plist
-cat > "${APP_BUNDLE}/Contents/Info.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleName</key>
-    <string>${APP_NAME}</string>
-    <key>CFBundleDisplayName</key>
-    <string>${APP_NAME}</string>
-    <key>CFBundleIdentifier</key>
-    <string>dev.fsaldivar.pry</string>
-    <key>CFBundleVersion</key>
-    <string>${VERSION}</string>
-    <key>CFBundleShortVersionString</key>
-    <string>${VERSION}</string>
-    <key>CFBundleExecutable</key>
-    <string>${APP_NAME}</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleIconFile</key>
-    <string>AppIcon</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
-    <key>NSHighResolutionCapable</key>
-    <true/>
-    <key>NSSupportsAutomaticTermination</key>
-    <true/>
-    <key>NSSupportsSuddenTermination</key>
-    <false/>
-    <key>LSApplicationCategoryType</key>
-    <string>public.app-category.developer-tools</string>
-</dict>
-</plist>
-PLIST
+# Generate Info.plist from template (replace Xcode variables with actual values)
+sed -e "s/\$(PRODUCT_BUNDLE_IDENTIFIER)/dev.fsaldivar.pry/g" \
+    -e "s/\$(CURRENT_PROJECT_VERSION)/${VERSION}/g" \
+    -e "s/\$(MARKETING_VERSION)/${VERSION}/g" \
+    -e "s/\$(EXECUTABLE_NAME)/${APP_NAME}/g" \
+    -e "s/\$(MACOSX_DEPLOYMENT_TARGET)/14.0/g" \
+    "${RESOURCES_DIR}/Info.plist" > "${APP_BUNDLE}/Contents/Info.plist"
+
+# Copy asset catalog (if compiled assets exist, otherwise copy raw)
+if [ -d "${BIN_PATH}/PryApp_PryApp.bundle" ]; then
+    cp -R "${BIN_PATH}/PryApp_PryApp.bundle/"* "${APP_BUNDLE}/Contents/Resources/" 2>/dev/null || true
+fi
+
+# Copy entitlements (for reference, used during codesign)
+cp "${RESOURCES_DIR}/PryApp.entitlements" "${APP_BUNDLE}/Contents/Resources/"
 
 echo "==> App bundle created: ${APP_BUNDLE}"
 echo "    Binary: $(file "${APP_BUNDLE}/Contents/MacOS/${APP_NAME}")"


### PR DESCRIPTION
## Summary
Adds proper Xcode project generation via **XcodeGen** for IDE integration, debugging with breakpoints, SwiftUI previews, and future code signing.

- **`project.yml`**: XcodeGen spec that generates `Pry.xcodeproj` (not committed, in `.gitignore`)
- **`Info.plist`**: Template with Xcode build variables (`$(PRODUCT_BUNDLE_IDENTIFIER)`, etc.)
- **`PryApp.entitlements`**: Network client/server permissions (sandbox disabled — required for proxy port binding and CA file access)
- **`Assets.xcassets`**: App icon catalog with macOS size slots (placeholder — add images later)
- **`Package.swift`**: Added `resources: [.process("Resources")]` to PryApp target
- **`build-app.sh`**: Now uses Info.plist template via sed + semver validation

### Usage
```bash
xcodegen generate       # creates Pry.xcodeproj
open Pry.xcodeproj      # Cmd+R to build & run
```

## Test plan
- [x] `xcodegen generate` → creates Pry.xcodeproj without errors
- [x] `xcodebuild -scheme PryApp build` → **BUILD SUCCEEDED**
- [x] `swift build` → still works (SPM not broken)
- [x] `swift test` → 138 tests, 0 failures
- [x] `bash scripts/build-app.sh 1.0.0` → 16MB .app bundle generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)