### PR TITLE
PryApp: complete UX redesign + dark theme + brand identity

### DIFF
--- a/Sources/PryApp/ContentView.swift
+++ b/Sources/PryApp/ContentView.swift
@@ -7,6 +7,14 @@ struct ContentView: View {
             .frame(minWidth: 900, minHeight: 600)
             .tint(PryTheme.accent)
             .preferredColorScheme(.dark)
-            .background(PryTheme.bgMain)
+            .background(PryTheme.bgMain.ignoresSafeArea())
+            .onAppear {
+                // Belt-and-suspenders: force NSWindow bg color
+                DispatchQueue.main.async {
+                    for window in NSApplication.shared.windows {
+                        window.backgroundColor = PryTheme.nsBgMain
+                    }
+                }
+            }
     }
 }

--- a/Sources/PryApp/MainWindow.swift
+++ b/Sources/PryApp/MainWindow.swift
@@ -13,6 +13,7 @@ struct MainWindow: View {
     @State private var showRules = false
     @State private var sidebarWidth: CGFloat = 220
     @State private var detailHeight: CGFloat = 280
+    @State private var showSidebar = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -21,7 +22,6 @@ struct MainWindow: View {
             }
 
             if store.requests.isEmpty {
-                // Empty state
                 VStack(spacing: 16) {
                     Spacer()
                     Image(systemName: proxy.isRunning
@@ -41,31 +41,29 @@ struct MainWindow: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                // Main layout: sidebar | content (all with uniform bgMain)
                 HStack(spacing: 0) {
-                    // Sidebar with custom cards
-                    SidebarView()
-                        .frame(width: sidebarWidth)
+                    // Collapsible sidebar
+                    if showSidebar {
+                        SidebarView()
+                            .frame(width: sidebarWidth)
+                            .transition(.move(edge: .leading).combined(with: .opacity))
 
-                    // Vertical drag handle
-                    DragDivider(axis: .vertical) { delta in
-                        sidebarWidth = max(160, min(350, sidebarWidth + delta))
+                        DragDivider(axis: .vertical) { delta in
+                            sidebarWidth = max(140, min(300, sidebarWidth + delta))
+                        }
                     }
 
                     // Right content
                     VStack(spacing: 0) {
-                        // Top: filter + request list
                         VStack(spacing: 0) {
                             FilterBarView()
                             RequestListView()
                         }
 
-                        // Horizontal drag handle
                         DragDivider(axis: .horizontal) { delta in
-                            detailHeight = max(100, detailHeight - delta)
+                            detailHeight = max(80, detailHeight - delta)
                         }
 
-                        // Bottom: detail panel
                         DetailPanelView()
                             .frame(height: detailHeight)
                     }
@@ -77,6 +75,16 @@ struct MainWindow: View {
         .background(PryTheme.bgMain)
         .toolbarBackground(.hidden)
         .toolbar {
+            // Sidebar toggle
+            ToolbarItem(placement: .navigation) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { showSidebar.toggle() }
+                } label: {
+                    Image(systemName: "sidebar.left")
+                }
+                .help("Toggle Sidebar (⌘0)")
+                .keyboardShortcut("0", modifiers: .command)
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button { toggleProxy() } label: {
                     Image(systemName: proxy.isRunning ? "stop.fill" : "play.fill")
@@ -140,7 +148,6 @@ struct DragDivider: View {
     var body: some View {
         Group {
             if axis == .vertical {
-                // Sidebar ↔ Content divider
                 Rectangle()
                     .fill(Color.white.opacity(0.06))
                     .frame(width: 1)
@@ -153,7 +160,6 @@ struct DragDivider: View {
                         .onChanged { value in onDrag(value.translation.width) }
                     )
             } else {
-                // List ↕ Detail divider
                 Rectangle()
                     .fill(Color.white.opacity(0.06))
                     .frame(height: 1)

--- a/Sources/PryApp/PryApp.swift
+++ b/Sources/PryApp/PryApp.swift
@@ -27,7 +27,7 @@ struct PryApp: App {
                 .environment(proxyManager)
         }
 
-        MenuBarExtra("Pry", systemImage: "cat.fill") {
+        MenuBarExtra("Pry", systemImage: "cat") {
             PryMenuBarContent()
                 .environment(proxyManager)
                 .environment(requestStore)

--- a/Sources/PryApp/PryApp.swift
+++ b/Sources/PryApp/PryApp.swift
@@ -1,21 +1,16 @@
 import SwiftUI
+import AppKit
 import PryKit
 
 @available(macOS 14, *)
 @MainActor
 @main
 struct PryApp: App {
+    @NSApplicationDelegateAdaptor(PryAppDelegate.self) var delegate
     @State private var proxyManager = ProxyManager()
     @State private var requestStore = RequestStoreWrapper()
     @State private var mockManager = MockManager()
     @State private var breakpointManager = BreakpointUIManager()
-
-    init() {
-        // Ensure the app activates as a regular foreground app even when
-        // launched from the command line (e.g. `PryApp &`).
-        NSApplication.shared.setActivationPolicy(.regular)
-        NSApplication.shared.activate(ignoringOtherApps: true)
-    }
 
     var body: some Scene {
         WindowGroup {
@@ -38,5 +33,31 @@ struct PryApp: App {
                 .environment(requestStore)
         }
         .menuBarExtraStyle(.window)
+    }
+}
+
+// MARK: - AppDelegate for window-level configuration
+
+@available(macOS 14, *)
+final class PryAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Force dark appearance and custom background on ALL windows
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        applyWindowBackground()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        applyWindowBackground()
+    }
+
+    private func applyWindowBackground() {
+        let bgColor = NSColor(red: 13/255, green: 17/255, blue: 23/255, alpha: 1) // #0D1117
+        for window in NSApplication.shared.windows {
+            window.backgroundColor = bgColor
+            window.appearance = NSAppearance(named: .darkAqua)
+            window.titlebarAppearsTransparent = true
+            window.isMovableByWindowBackground = true
+        }
     }
 }

--- a/Sources/PryApp/Views/FilterBarView.swift
+++ b/Sources/PryApp/Views/FilterBarView.swift
@@ -116,5 +116,13 @@ struct FilterBarView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(PryTheme.bgHeader)
+        // Cmd+F focuses the search field
+        .onKeyPress(.init("f"), phases: .down) { event in
+            guard event.modifiers.contains(.command) else { return .ignored }
+            if let field = SearchFieldView.activeField {
+                field.window?.makeFirstResponder(field)
+            }
+            return .handled
+        }
     }
 }

--- a/Sources/PryApp/Views/RequestListView.swift
+++ b/Sources/PryApp/Views/RequestListView.swift
@@ -22,8 +22,8 @@ struct RequestListView: NSViewRepresentable {
             ("icon",     "",         28,  false),
             ("method",   "Method",   68,  false),
             ("status",   "Status",   56,  false),
-            ("host",     "Host",     150, false),
-            ("path",     "Path",     200, true),   // stretches to fill
+            ("host",     "Host",     120, true),   // flexible
+            ("path",     "Path",     150, true),   // flexible
             ("duration", "Duration", 64,  false),
             ("time",     "Time",     60,  false),
         ]

--- a/Sources/PryApp/Views/SearchFieldView.swift
+++ b/Sources/PryApp/Views/SearchFieldView.swift
@@ -8,6 +8,9 @@ struct SearchFieldView: NSViewRepresentable {
     @Binding var text: String
     var placeholder: String = "Filter…"
 
+    /// Shared reference so Cmd+F can focus the field from anywhere.
+    static weak var activeField: NSSearchField?
+
     func makeNSView(context: Context) -> NSSearchField {
         let field = NSSearchField()
         field.placeholderString = placeholder
@@ -16,9 +19,9 @@ struct SearchFieldView: NSViewRepresentable {
         field.delegate = context.coordinator
         field.target = context.coordinator
         field.action = #selector(Coordinator.textChanged(_:))
-        // Continuous search — filter as you type
         field.sendsSearchStringImmediately = true
         field.sendsWholeSearchString = false
+        Self.activeField = field
         return field
     }
 

--- a/Sources/PryApp/Views/SidebarView.swift
+++ b/Sources/PryApp/Views/SidebarView.swift
@@ -97,6 +97,7 @@ struct SidebarView: View {
                     Text("\(store.requests.count) peticiones")
                         .font(.caption)
                         .foregroundStyle(PryTheme.textSecondary)
+                        .lineLimit(1)
                 }
 
                 Spacer()
@@ -161,6 +162,7 @@ struct SidebarView: View {
                     Text("\(group.total) peticiones")
                         .font(.caption)
                         .foregroundStyle(PryTheme.textSecondary)
+                        .lineLimit(1)
                 }
 
                 Spacer()


### PR DESCRIPTION
## Summary

Complete visual and UX overhaul of PryApp across 13 commits:

**Layout & Controls**
- HSplitView replaced with HStack + custom DragDivider for uniform dark background
- Collapsible sidebar with Cmd+0 toggle and drag-to-resize
- Segmented picker + Copy cURL button in detail panel
- NSSearchField for filter (Cmd+F focuses it)
- Method/Status compact dropdown menus with icon buttons
- Responsive: Host and Path columns both flexible

**Dark Theme (PryTheme)**
- Complete color palette from TUI (#0D1117 bg, #00E5FF accent, #E6EDF3 text)
- NSWindow.backgroundColor forced to #0D1117 (persists in fullscreen)
- Transparent titlebar blends with content
- Forced dark mode + .tint(PryTheme.accent) on root

**Visual Polish**
- Method badges: colored pills (GET emerald, POST amber, DELETE red, PUT orange)
- Status dots: colored circles replacing emoji icons
- Column headers: UPPERCASE 9pt semibold
- Row height 32pt with grid lines (white 6%)
- Path shows relative path (/get) not full URL
- Custom SidebarView with app cards, SF Symbol icons, security info card
- Footer bar: proxy status, SSL info, request count in uppercase tracking
- Modern colors: emerald #10B981, red #EF4444, amber #F59E0B

**Brand Identity**
- AccentColor.colorset (cyan #00E5FF dark, #00ACC1 light)
- App icon generated from logo.png (all macOS sizes)
- Menu bar icon: cat outline (not filled)
- JSON syntax: cyan keys, green strings, amber numbers, blue bools

**Fixes**
- Sheets (Mocks/Breakpoints/Rules) have Done button + Escape to dismiss
- App activates as foreground when launched from terminal
- CI fix: removed GlassCompat.swift (.glassEffect requires macOS 26 SDK)

## Test plan
- [x] `swift build` — no errors
- [x] `swift test` — 138 tests, 0 failures
- [x] Uniform dark background in normal/maximized/fullscreen
- [x] Cmd+0 toggles sidebar
- [x] Cmd+F focuses search field
- [x] Method badges centered with correct colors
- [x] Right-click context menu works
- [x] Filter field accepts text
- [x] Sidebar resize via drag divider

Closes #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)