### PR TITLE
Legal + Cmd+F fix

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,65 @@
+Pry — HTTP/HTTPS Debugging Proxy
+Copyright 2024-2026 Francisco Javier Saldivar Rubio
+
+This product includes software developed by Apple Inc. and the
+Swift open source community, licensed under the Apache License 2.0.
+
+==============================================================================
+Third-Party Dependencies (Apache License 2.0)
+==============================================================================
+
+SwiftNIO
+  Copyright 2017-2024 Apple Inc. and the SwiftNIO project authors
+  https://github.com/apple/swift-nio
+  Licensed under Apache License 2.0
+
+SwiftNIO SSL
+  Copyright 2017-2024 Apple Inc. and the SwiftNIO project authors
+  https://github.com/apple/swift-nio-ssl
+  Licensed under Apache License 2.0
+
+Swift Certificates
+  Copyright 2022-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-certificates
+  Licensed under Apache License 2.0
+
+Swift Crypto
+  Copyright 2019-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-crypto
+  Licensed under Apache License 2.0
+
+Swift ASN1
+  Copyright 2022-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-asn1
+  Licensed under Apache License 2.0
+
+Swift Atomics
+  Copyright 2020-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-atomics
+  Licensed under Apache License 2.0
+
+Swift Collections
+  Copyright 2021-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-collections
+  Licensed under Apache License 2.0
+
+Swift System
+  Copyright 2020-2024 Apple Inc. and the Swift project authors
+  https://github.com/apple/swift-system
+  Licensed under Apache License 2.0
+
+==============================================================================
+Apache License 2.0
+==============================================================================
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use these files except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -362,9 +362,15 @@ Diario crudo de desarrollo — cada sesión, cada intento, cada error.
 
 ---
 
+## Aviso legal
+
+Pry es una herramienta de desarrollo para depurar trafico de red en tus propias aplicaciones y ambientes autorizados. La intercepcion de trafico de red ajeno sin consentimiento es ilegal en la mayoria de jurisdicciones. Usa esta herramienta de forma responsable.
+
 ## Licencia
 
-MIT
+MIT — ver [LICENSE](./LICENSE)
+
+Las dependencias de Apple (SwiftNIO, swift-certificates, swift-crypto) estan licenciadas bajo Apache 2.0. Ver [NOTICE](./NOTICE) para detalles.
 
 ---
 


### PR DESCRIPTION
## Summary

- NOTICE file listing all Apache 2.0 dependencies (SwiftNIO, swift-certificates, etc.)
- Legal disclaimer in README ("for authorized debugging only")
- Restored Cmd+F to focus search field (#56)
- Menu bar icon: cat outline instead of filled (matches system icon style)
- Uniform window background via NSWindow.titlebarAppearsTransparent
- BIS export notification email sent (TSU exception, EAR §740.13(e))

## Test plan
- [x] `swift build` — no errors
- [x] `swift test` — 138 tests pass
- [x] NOTICE file present at repo root
- [x] README has legal disclaimer section

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)