### PR TITLE
feat: orphan proxy detection + cleanup guarantees (#73)

### DIFF
--- a/Sources/Pry/main.swift
+++ b/Sources/Pry/main.swift
@@ -74,6 +74,9 @@ guard let command = args.first else {
     exit(0)
 }
 
+// Check for orphaned proxy config on every CLI invocation
+ProxyGuard.cleanupIfNeeded()
+
 switch command {
 case "start":
     var port = Config.defaultPort
@@ -117,16 +120,25 @@ case "start":
     }
 
     let server = ProxyServer(port: port)
+    ProxyGuard.installAtexitHandler()
     let headless = args.contains("--headless")
 
     if headless {
         // Headless mode — direct print, blocking
         signal(SIGINT) { _ in
             print("\n🐱 Pry stopped")
+            if let state = ProxyState.load() {
+                SystemProxy.disable(service: state.networkService)
+            }
+            ProxyState.clear()
             try? FileManager.default.removeItem(atPath: Config.pidFile)
             exit(0)
         }
         signal(SIGTERM) { _ in
+            if let state = ProxyState.load() {
+                SystemProxy.disable(service: state.networkService)
+            }
+            ProxyState.clear()
             try? FileManager.default.removeItem(atPath: Config.pidFile)
             exit(0)
         }
@@ -243,8 +255,12 @@ case "start":
         tui.start()
 
         // TUI exited — cleanup
+        if let state = ProxyState.load(),
+           state.pid == ProcessInfo.processInfo.processIdentifier {
+            SystemProxy.disable(service: state.networkService)
+            ProxyState.clear()
+        }
         server.shutdown()
-        try? FileManager.default.removeItem(atPath: Config.pidFile)
     }
 
 case "stop":

--- a/Sources/PryApp/PryApp.swift
+++ b/Sources/PryApp/PryApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import PryKit
+import PryLib
 
 @available(macOS 14, *)
 @MainActor
@@ -41,6 +42,8 @@ struct PryApp: App {
 @available(macOS 14, *)
 final class PryAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Clean up orphaned proxy config from a previous crash
+        ProxyGuard.cleanupIfNeeded()
         // Force dark appearance and custom background on ALL windows
         NSApplication.shared.setActivationPolicy(.regular)
         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/Sources/PryKit/ProxyManager.swift
+++ b/Sources/PryKit/ProxyManager.swift
@@ -17,6 +17,8 @@ public final class ProxyManager {
 
     public init(port: Int = Config.port()) {
         self.port = port
+        // Check for orphaned proxy config from a previous crash
+        ProxyGuard.cleanupIfNeeded()
     }
 
     public func start() throws {
@@ -65,6 +67,7 @@ public final class ProxyManager {
     deinit {
         // Ensure system proxy is restored even on unexpected termination
         SystemProxy.disable()
+        ProxyState.clear()
         serverBox.shutdownIfNeeded()
     }
 }

--- a/Sources/PryLib/ProxyGuard.swift
+++ b/Sources/PryLib/ProxyGuard.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Orchestrates proxy cleanup to prevent orphaned system proxy configurations.
+/// Call `cleanupIfNeeded()` on every app/CLI launch.
+public struct ProxyGuard {
+
+    /// Check for orphaned proxy config and clean up if found.
+    /// Should be called early in every CLI invocation and GUI launch.
+    public static func cleanupIfNeeded() {
+        // Primary: check state file for orphaned process
+        if let orphan = ProxyState.isOrphaned() {
+            SystemProxy.disable(service: orphan.networkService)
+            ProxyState.clear()
+            // Also clean up stale PID file
+            try? FileManager.default.removeItem(atPath: Config.pidFile)
+            fputs("[ProxyGuard] Cleaned up orphaned proxy config (PID \(orphan.pid) on \(orphan.networkService))\n", stderr)
+            return
+        }
+
+        // Fallback: no state file, but system proxy might still be pointing at us
+        // This handles the case where state file was lost
+        if ProxyState.load() == nil {
+            let port = Config.port()
+            if SystemProxy.isEnabled(port: port) && !isProcessListeningOn(port: port) {
+                SystemProxy.disable()
+                fputs("[ProxyGuard] Cleaned up stale system proxy on port \(port)\n", stderr)
+            }
+        }
+    }
+
+    /// Install signal handlers that clean up proxy state on termination.
+    public static func installSignalHandlers() {
+        signal(SIGINT) { _ in
+            ProxyGuard.emergencyCleanup()
+            exit(0)
+        }
+        signal(SIGTERM) { _ in
+            ProxyGuard.emergencyCleanup()
+            exit(0)
+        }
+        signal(SIGHUP) { _ in
+            ProxyGuard.emergencyCleanup()
+            exit(0)
+        }
+    }
+
+    /// Install atexit handler for normal exit paths.
+    public static func installAtexitHandler() {
+        atexit {
+            // Only clean up if we still have a state file with our PID
+            if let state = ProxyState.load(),
+               state.pid == ProcessInfo.processInfo.processIdentifier {
+                SystemProxy.disable(service: state.networkService)
+                ProxyState.clear()
+                try? FileManager.default.removeItem(atPath: Config.pidFile)
+            }
+        }
+    }
+
+    /// Emergency cleanup — called from signal handlers.
+    /// Must be async-signal-safe where possible.
+    private static func emergencyCleanup() {
+        if let state = ProxyState.load() {
+            SystemProxy.disable(service: state.networkService)
+        }
+        ProxyState.clear()
+        try? FileManager.default.removeItem(atPath: Config.pidFile)
+    }
+
+    /// Check if any process is listening on the given port.
+    private static func isProcessListeningOn(port: Int) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-i", ":\(port)", "-t"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        } catch {
+            return false
+        }
+    }
+}

--- a/Sources/PryLib/ProxyState.swift
+++ b/Sources/PryLib/ProxyState.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Persistent proxy state — written when system proxy is enabled, cleared on disable.
+/// Survives crashes. Used by ProxyGuard to detect orphaned proxy configurations.
+public struct ProxyState: Codable {
+    public let port: Int
+    public let pid: Int32
+    public let networkService: String
+    public let enabledAt: Date
+
+    public static let stateFile = NSHomeDirectory() + "/.pry/proxy.state"
+
+    /// Save proxy state atomically to disk.
+    public static func save(port: Int, pid: Int32, networkService: String) {
+        let state = ProxyState(port: port, pid: pid, networkService: networkService, enabledAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(state) else { return }
+        // Ensure directory exists
+        let dir = (stateFile as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? data.write(to: URL(fileURLWithPath: stateFile), options: .atomic)
+    }
+
+    /// Load proxy state from disk. Returns nil if file doesn't exist or is corrupted.
+    public static func load() -> ProxyState? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: stateFile)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(ProxyState.self, from: data)
+    }
+
+    /// Delete the state file.
+    public static func clear() {
+        try? FileManager.default.removeItem(atPath: stateFile)
+    }
+
+    /// Check if the recorded proxy state is orphaned (process is dead).
+    /// Returns the state if orphaned, nil if alive or no state file.
+    public static func isOrphaned() -> ProxyState? {
+        guard let state = load() else { return nil }
+        // kill with signal 0 checks if process exists without sending a signal
+        if kill(state.pid, 0) != 0 {
+            // Process is dead — orphan detected
+            return state
+        }
+        return nil
+    }
+}

--- a/Sources/PryLib/SystemProxy.swift
+++ b/Sources/PryLib/SystemProxy.swift
@@ -56,6 +56,7 @@ public struct SystemProxy {
         run("/usr/sbin/networksetup", ["-setwebproxystate", service, "on"])
         run("/usr/sbin/networksetup", ["-setsecurewebproxystate", service, "on"])
         print("[SystemProxy] Enabled on \(service) → localhost:\(port)")
+        ProxyState.save(port: port, pid: ProcessInfo.processInfo.processIdentifier, networkService: service)
     }
 
     /// Disable HTTP + HTTPS proxy on the active network service.
@@ -64,9 +65,16 @@ public struct SystemProxy {
             print("[SystemProxy] Could not detect active network service")
             return
         }
+        disable(service: service)
+        ProxyState.clear()
+    }
+
+    /// Disable HTTP + HTTPS proxy on a specific network service.
+    public static func disable(service: String) {
         run("/usr/sbin/networksetup", ["-setwebproxystate", service, "off"])
         run("/usr/sbin/networksetup", ["-setsecurewebproxystate", service, "off"])
         print("[SystemProxy] Disabled on \(service)")
+        ProxyState.clear()
     }
 
     /// Check if system proxy is currently pointing to our port.

--- a/Tests/PryLibTests/ProxyStateTests.swift
+++ b/Tests/PryLibTests/ProxyStateTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import PryLib
+
+final class ProxyStateTests: XCTestCase {
+    private var originalStateFile: String!
+    private var tempDir: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = NSTemporaryDirectory() + "pry-test-\(UUID().uuidString)"
+        try? FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: tempDir)
+        super.tearDown()
+    }
+
+    private var testStateFile: String { tempDir + "/proxy.state" }
+
+    // Helper: save state to temp file
+    private func saveState(port: Int = 8080, pid: Int32 = 12345, service: String = "Wi-Fi") {
+        let state = ProxyState(port: port, pid: pid, networkService: service, enabledAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try! encoder.encode(state)
+        try! data.write(to: URL(fileURLWithPath: testStateFile), options: .atomic)
+    }
+
+    private func loadState() -> ProxyState? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: testStateFile)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(ProxyState.self, from: data)
+    }
+
+    func testSaveAndLoad() {
+        // Test using the real ProxyState API
+        ProxyState.save(port: 9090, pid: 42, networkService: "Ethernet")
+        let loaded = ProxyState.load()
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.port, 9090)
+        XCTAssertEqual(loaded?.pid, 42)
+        XCTAssertEqual(loaded?.networkService, "Ethernet")
+        XCTAssertNotNil(loaded?.enabledAt)
+        // Cleanup
+        ProxyState.clear()
+    }
+
+    func testClear() {
+        ProxyState.save(port: 8080, pid: 1, networkService: "Wi-Fi")
+        XCTAssertNotNil(ProxyState.load())
+        ProxyState.clear()
+        XCTAssertNil(ProxyState.load())
+    }
+
+    func testIsOrphanedWithDeadPID() {
+        // PID 999999 is almost certainly not running
+        ProxyState.save(port: 8080, pid: 999999, networkService: "Wi-Fi")
+        let orphan = ProxyState.isOrphaned()
+        XCTAssertNotNil(orphan)
+        XCTAssertEqual(orphan?.pid, 999999)
+        XCTAssertEqual(orphan?.networkService, "Wi-Fi")
+        ProxyState.clear()
+    }
+
+    func testIsOrphanedWithAlivePID() {
+        // Current process PID is alive
+        let myPid = ProcessInfo.processInfo.processIdentifier
+        ProxyState.save(port: 8080, pid: myPid, networkService: "Wi-Fi")
+        let orphan = ProxyState.isOrphaned()
+        XCTAssertNil(orphan)
+        ProxyState.clear()
+    }
+
+    func testIsOrphanedWithNoFile() {
+        ProxyState.clear() // Ensure no file
+        XCTAssertNil(ProxyState.isOrphaned())
+    }
+
+    func testStateEncodesAsJSON() {
+        ProxyState.save(port: 8080, pid: 123, networkService: "Wi-Fi")
+        let data = try! Data(contentsOf: URL(fileURLWithPath: ProxyState.stateFile))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["port"] as? Int, 8080)
+        XCTAssertEqual(json["pid"] as? Int, 123)
+        XCTAssertEqual(json["networkService"] as? String, "Wi-Fi")
+        XCTAssertNotNil(json["enabledAt"])
+        ProxyState.clear()
+    }
+}


### PR DESCRIPTION
## Summary

- Prevents losing internet when PryApp crashes or is force-quit while system proxy is active
- Adds `ProxyState` — persistent JSON state at `~/.pry/proxy.state` that survives crashes
- Adds `ProxyGuard` — cleanup orchestrator that detects orphaned proxy configs on every CLI invocation and GUI launch
- Multi-layer defense: signal handlers, atexit, on-launch check (catches SIGKILL/OOM)

## Changes

| File | Change |
|------|--------|
| `Sources/PryLib/ProxyState.swift` | **New** — persistent proxy state (save/load/clear/isOrphaned) |
| `Sources/PryLib/ProxyGuard.swift` | **New** — orphan detection + cleanup orchestration |
| `Tests/PryLibTests/ProxyStateTests.swift` | **New** — 6 unit tests |
| `Sources/PryLib/SystemProxy.swift` | Added `disable(service:)`, auto-save state on enable |
| `Sources/Pry/main.swift` | Cleanup on every CLI invocation, improved signal handlers |
| `Sources/PryKit/ProxyManager.swift` | Cleanup in init + ProxyState.clear() in deinit |
| `Sources/PryApp/PryApp.swift` | Cleanup in applicationDidFinishLaunching |

## Test plan

- [x] `swift build` — compiles without errors
- [x] `swift test --filter ProxyState` — 6/6 tests pass
- [ ] Manual: `pry start --headless &` → `kill -9 $PID` → `pry list` → verify proxy config cleaned
- [ ] Manual: Open PryApp → Start proxy → Force quit → Reopen → verify orphan detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)