### PR TITLE
feat: UI polish + device setup + edit mocks + source filter (closes #67-#72)

### DIFF
--- a/Sources/PryApp/MainWindow.swift
+++ b/Sources/PryApp/MainWindow.swift
@@ -12,6 +12,7 @@ struct MainWindow: View {
     @State private var showMocking = false
     @State private var showBreakpoints = false
     @State private var showRules = false
+    @State private var showDeviceSetup = false
     @State private var sidebarWidth: CGFloat = 220
     @State private var detailHeight: CGFloat = 280
     @State private var showSidebar = true
@@ -121,6 +122,12 @@ struct MainWindow: View {
                     Text("Rules")
                 }
             }
+            ToolbarItem(placement: .automatic) {
+                Button { showDeviceSetup.toggle() } label: {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                    Text("Device")
+                }
+            }
         }
         .sheet(isPresented: $showMocking) {
             UnifiedMockView().frame(minWidth: 800, minHeight: 500)
@@ -130,6 +137,9 @@ struct MainWindow: View {
         }
         .sheet(isPresented: $showRules) {
             RulesEditorView().frame(minWidth: 600, minHeight: 500)
+        }
+        .sheet(isPresented: $showDeviceSetup) {
+            DeviceSetupView().frame(minWidth: 450, minHeight: 400)
         }
     }
 

--- a/Sources/PryApp/Views/DeviceSetupView.swift
+++ b/Sources/PryApp/Views/DeviceSetupView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import PryKit
+import PryLib
+import NIO
+
+@available(macOS 14, *)
+@MainActor
+struct DeviceSetupView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(ProxyManager.self) private var proxy
+
+    @State private var serverChannel: Channel?
+    @State private var isServerRunning = false
+
+    private var localIP: String {
+        DeviceOnboarding.localIPAddresses().first ?? "unknown"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Device Setup")
+                    .font(.headline)
+                Spacer()
+                Button("Done") {
+                    stopServer()
+                    dismiss()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            VStack(spacing: 16) {
+                // IP + Port info
+                VStack(spacing: 4) {
+                    Text("Proxy Address")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(localIP):\(String(proxy.port))")
+                        .font(.system(size: 24, weight: .bold, design: .monospaced))
+                        .foregroundStyle(PryTheme.accent)
+                        .textSelection(.enabled)
+                }
+
+                // Setup page URL
+                if isServerRunning {
+                    VStack(spacing: 4) {
+                        Text("Setup Page")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("http://\(localIP):8081")
+                            .font(.system(size: 16, design: .monospaced))
+                            .foregroundStyle(PryTheme.success)
+                            .textSelection(.enabled)
+                    }
+
+                    Text("Open this URL on your device to configure it")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    Button("Open in Browser") {
+                        if let url = URL(string: "http://\(localIP):8081") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+
+                    Button("Stop Server") {
+                        stopServer()
+                    }
+                    .tint(.red)
+                } else {
+                    Text("Start the setup server so devices on your network\ncan configure the proxy automatically.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    Button {
+                        startServer()
+                    } label: {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                        Text("Start Setup Server")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!proxy.isRunning)
+
+                    if !proxy.isRunning {
+                        Text("Start the proxy first")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+
+                Divider()
+
+                // Instructions
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("MANUAL SETUP")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(PryTheme.textTertiary)
+                        .tracking(1.5)
+
+                    Text("1. On your device, go to Wi-Fi settings")
+                    Text("2. Set HTTP Proxy to: \(localIP):\(String(proxy.port))")
+                    Text("3. Download CA certificate from the setup page")
+                    Text("4. Install and trust the certificate")
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(20)
+
+            Spacer()
+        }
+    }
+
+    private func startServer() {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        do {
+            let channel = try DeviceOnboarding.startServer(port: 8081, proxyPort: proxy.port, group: group)
+            serverChannel = channel
+            isServerRunning = true
+        } catch {
+            print("Failed to start setup server: \(error)")
+        }
+    }
+
+    private func stopServer() {
+        try? serverChannel?.close().wait()
+        serverChannel = nil
+        isServerRunning = false
+    }
+}

--- a/Sources/PryApp/Views/FilterBarView.swift
+++ b/Sources/PryApp/Views/FilterBarView.swift
@@ -95,14 +95,52 @@ struct FilterBarView: View {
             }
             .buttonStyle(.borderless)
 
+            // Source filter — mocked vs real
+            Menu {
+                Button("All Sources") { store.filterMockSource = .all }
+                Divider()
+                ForEach(MockSourceFilter.allCases.filter { $0 != .all }, id: \.self) { source in
+                    Button {
+                        store.filterMockSource = store.filterMockSource == source ? .all : source
+                    } label: {
+                        HStack {
+                            Text(source.rawValue)
+                            if store.filterMockSource == source {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                let isActive = store.filterMockSource != .all
+                HStack(spacing: 4) {
+                    Image(systemName: "shippingbox")
+                        .font(.system(size: 10))
+                    Text(isActive ? store.filterMockSource.rawValue : "Source")
+                        .font(.system(size: 11, weight: isActive ? .semibold : .regular))
+                }
+                .foregroundStyle(isActive ? PryTheme.accent : PryTheme.textSecondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(isActive ? PryTheme.accent.opacity(0.12) : Color.white.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+            }
+            .buttonStyle(.borderless)
+
             // Clear all
             let hasActive = store.filterMethod != nil ||
                             store.filterStatus != nil ||
+                            store.filterMockSource != .all ||
                             !store.filterText.isEmpty
             if hasActive {
                 Button {
                     store.filterMethod = nil
                     store.filterStatus = nil
+                    store.filterMockSource = .all
                     store.filterText = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")

--- a/Sources/PryApp/Views/RequestListView.swift
+++ b/Sources/PryApp/Views/RequestListView.swift
@@ -421,16 +421,17 @@ struct RequestListView: NSViewRepresentable {
 
         @objc private func mockRequest(_ sender: NSMenuItem) {
             guard let req = sender.representedObject as? RequestStore.CapturedRequest else { return }
-            // Extract URL path for mock pattern
-            let pattern: String
-            if let url = URL(string: req.url) {
-                pattern = url.path.isEmpty ? "/" : url.path
-            } else {
-                pattern = req.url
-            }
-            let body = req.responseBody ?? "{}"
-            Config.saveMock(path: pattern, response: body)
-            print("[PryApp] Mocked \(req.method) \(pattern)")
+            let pattern = req.url.hasPrefix("/") ? req.url : "/\(req.url)"
+            let mock = UnifiedMock(
+                method: req.method,
+                pattern: pattern,
+                host: req.host,
+                status: req.statusCode ?? 200,
+                body: req.responseBody ?? "{}",
+                source: .loose,
+                isEnabled: true
+            )
+            MockEngine.shared.addLooseMock(mock)
         }
 
         // MARK: - Badge colors

--- a/Sources/PryApp/Views/UnifiedMockView.swift
+++ b/Sources/PryApp/Views/UnifiedMockView.swift
@@ -271,9 +271,12 @@ struct UnifiedMockView: View {
             } else {
                 List {
                     ForEach(mocks, id: \.id) { mock in
-                        UnifiedMockRow(mock: mock) {
+                        UnifiedMockRow(mock: mock, onDelete: {
                             MockEngine.shared.removeLooseMock(id: mock.id)
-                        }
+                        }, onSave: { updated in
+                            MockEngine.shared.removeLooseMock(id: mock.id)
+                            MockEngine.shared.addLooseMock(updated)
+                        })
                     }
                 }
                 .listStyle(.inset)
@@ -462,12 +465,26 @@ struct UnifiedMockView: View {
                 } else {
                     List {
                         ForEach(scenarioData.mocks, id: \.id) { mock in
-                            UnifiedMockRow(mock: mock) {
-                                // Remove mock from scenario
+                            UnifiedMockRow(mock: mock, onDelete: {
+                                // Remove mock from scenario and reload MockEngine
                                 var updated = scenarioData
                                 updated.mocks.removeAll { $0.id == mock.id }
                                 try? projectManager.saveScenario(updated, project: project)
-                            }
+                                if projectManager.activeProject == project && projectManager.activeScenario == scenario {
+                                    MockEngine.shared.loadScenarioMocks(updated.mocks)
+                                }
+                            }, onSave: { editedMock in
+                                // Replace mock in scenario and reload MockEngine
+                                var updated = scenarioData
+                                if let idx = updated.mocks.firstIndex(where: { $0.id == mock.id }) {
+                                    updated.mocks[idx] = editedMock
+                                }
+                                try? projectManager.saveScenario(updated, project: project)
+                                // Reload mocks in engine if this scenario is active
+                                if projectManager.activeProject == project && projectManager.activeScenario == scenario {
+                                    MockEngine.shared.loadScenarioMocks(updated.mocks)
+                                }
+                            })
                         }
                     }
                     .listStyle(.inset)
@@ -489,8 +506,9 @@ struct UnifiedMockView: View {
 @MainActor private struct UnifiedMockRow: View {
     let mock: UnifiedMock
     let onDelete: () -> Void
+    let onSave: (UnifiedMock) -> Void
     @State private var showDeleteConfirmation = false
-    @State private var showDetail = false
+    @State private var showEdit = false
 
     var body: some View {
         HStack(spacing: 8) {
@@ -515,7 +533,7 @@ struct UnifiedMockView: View {
                         .lineLimit(1)
                 }
             }
-            .onTapGesture { showDetail = true }
+            .onTapGesture { showEdit = true }
 
             Spacer()
 
@@ -548,9 +566,9 @@ struct UnifiedMockView: View {
                 Button("Delete", role: .destructive, action: onDelete)
             }
         }
-        .sheet(isPresented: $showDetail) {
-            MockDetailView(mock: mock)
-                .frame(minWidth: 500, minHeight: 400)
+        .sheet(isPresented: $showEdit) {
+            MockEditView(mock: mock, onSave: onSave)
+                .frame(minWidth: 500, minHeight: 450)
         }
     }
 
@@ -562,20 +580,46 @@ struct UnifiedMockView: View {
     }
 }
 
-// MARK: - Mock Detail View
+// MARK: - Mock Edit View
 
 @available(macOS 14, *)
-@MainActor private struct MockDetailView: View {
+@MainActor private struct MockEditView: View {
     @Environment(\.dismiss) private var dismiss
     let mock: UnifiedMock
+    let onSave: (UnifiedMock) -> Void
+
+    @State private var method: String
+    @State private var pattern: String
+    @State private var host: String
+    @State private var status: UInt
+    @State private var bodyText: String
+    @State private var delay: String
+    @State private var notes: String
+    @State private var isEnabled: Bool
+
+    private let methods = ["ANY", "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+    init(mock: UnifiedMock, onSave: @escaping (UnifiedMock) -> Void) {
+        self.mock = mock
+        self.onSave = onSave
+        _method = State(initialValue: mock.method ?? "ANY")
+        _pattern = State(initialValue: mock.pattern)
+        _host = State(initialValue: mock.host ?? "")
+        _status = State(initialValue: mock.status)
+        _bodyText = State(initialValue: mock.body)
+        _delay = State(initialValue: mock.delay.map { String($0) } ?? "")
+        _notes = State(initialValue: mock.notes ?? "")
+        _isEnabled = State(initialValue: mock.isEnabled)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
+            // Header
             HStack {
-                Text("Mock Detail")
+                Text("Edit Mock")
                     .font(.headline)
                 Spacer()
-                Button("Done") { dismiss() }
+                Button("Cancel") { dismiss() }
                     .keyboardShortcut(.escape, modifiers: [])
             }
             .padding(.horizontal, 12)
@@ -583,108 +627,85 @@ struct UnifiedMockView: View {
 
             Divider()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    // Method + Status
-                    HStack(spacing: 8) {
-                        Text(mock.method ?? "ANY")
-                            .font(.system(size: 12, weight: .bold, design: .monospaced))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(PryTheme.methodColor(mock.method).opacity(0.2))
-                            .foregroundStyle(PryTheme.methodColor(mock.method))
-                            .clipShape(RoundedRectangle(cornerRadius: 3))
-
-                        Text("\(mock.status)")
-                            .font(.system(size: 12, weight: .bold, design: .monospaced))
-                            .foregroundStyle(PryTheme.statusColorSwiftUI(mock.status))
-
-                        if let delay = mock.delay, delay > 0 {
-                            Text("\(delay)ms delay")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        if let source = mock.source {
-                            Text(source.label)
-                                .font(.caption)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(PryTheme.accent.opacity(0.1))
-                                .foregroundStyle(PryTheme.accent)
-                                .clipShape(Capsule())
-                        }
-                    }
-
-                    // Pattern
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Pattern")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
-                        Text(mock.pattern)
-                            .font(.system(size: 13, design: .monospaced))
-                            .textSelection(.enabled)
-                    }
-
-                    // Host
-                    if let host = mock.host, !host.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Host")
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.secondary)
-                            Text(host)
-                                .font(.system(size: 13, design: .monospaced))
-                                .textSelection(.enabled)
-                        }
-                    }
-
-                    // Response Body
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Response Body")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(mock.body)
-                                .font(.system(size: 12, design: .monospaced))
-                                .textSelection(.enabled)
-                        }
-                        .frame(maxHeight: 200)
-                        .padding(8)
-                        .background(PryTheme.bgPanel)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                    }
-
-                    // Custom Headers
-                    if let headers = mock.headers, !headers.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Custom Headers")
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.secondary)
-                            ForEach(Array(headers.keys.sorted()), id: \.self) { key in
-                                HStack {
-                                    Text(key)
-                                        .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                        .foregroundStyle(PryTheme.accent)
-                                    Text(headers[key] ?? "")
-                                        .font(.system(size: 11, design: .monospaced))
-                                }
-                            }
-                        }
-                    }
-
-                    // Notes
-                    if let notes = mock.notes, !notes.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Notes")
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.secondary)
-                            Text(notes)
-                                .font(.system(size: 12))
-                        }
+            Form {
+                // Method picker
+                Picker("Method", selection: $method) {
+                    ForEach(methods, id: \.self) { m in
+                        Text(m).tag(m)
                     }
                 }
-                .padding(12)
+
+                // Pattern
+                TextField("URL Pattern (e.g. /api/users)", text: $pattern)
+                    .font(.system(size: 12, design: .monospaced))
+
+                // Host
+                TextField("Host (e.g. api.example.com)", text: $host)
+                    .font(.system(size: 12, design: .monospaced))
+
+                // Status
+                HStack {
+                    Text("Status")
+                    TextField("", value: $status, format: .number)
+                        .frame(width: 60)
+                    ForEach([200, 400, 401, 404, 500], id: \.self) { code in
+                        Button("\(code)") { status = UInt(code) }
+                            .font(.system(size: 10, design: .monospaced))
+                            .buttonStyle(.bordered)
+                            .controlSize(.mini)
+                    }
+                }
+
+                // Delay
+                TextField("Delay (ms)", text: $delay)
+
+                // Notes
+                TextField("Notes", text: $notes)
+
+                // Enabled toggle
+                Toggle("Enabled", isOn: $isEnabled)
+
+                // Response body
+                Section("Response Body") {
+                    TextEditor(text: $bodyText)
+                        .font(.system(size: 12, design: .monospaced))
+                        .frame(minHeight: 120)
+                }
             }
+            .padding(12)
+
+            Divider()
+
+            // Footer with source info + save
+            HStack {
+                if let source = mock.source {
+                    Text("Source: \(source.label)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Save") {
+                    let updated = UnifiedMock(
+                        id: mock.id,
+                        method: method == "ANY" ? nil : method,
+                        pattern: pattern,
+                        host: host.isEmpty ? nil : host,
+                        status: status,
+                        headers: mock.headers,
+                        body: bodyText,
+                        contentType: mock.contentType,
+                        delay: Int(delay),
+                        notes: notes.isEmpty ? nil : notes,
+                        source: mock.source,
+                        isEnabled: isEnabled
+                    )
+                    onSave(updated)
+                    dismiss()
+                }
+                .disabled(pattern.isEmpty)
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+            .padding(12)
         }
     }
 }

--- a/Sources/PryKit/RequestStoreWrapper.swift
+++ b/Sources/PryKit/RequestStoreWrapper.swift
@@ -10,6 +10,14 @@ public enum SourceFilter: Hashable, Sendable {
     case host(app: String, host: String)
 }
 
+/// Filter requests by mock/real origin.
+@available(macOS 14, *)
+public enum MockSourceFilter: String, CaseIterable, Sendable {
+    case all = "All"
+    case mocked = "Mocked"
+    case real = "Real"
+}
+
 /// @Observable bridge over RequestStore for SwiftUI.
 ///
 /// Debounces updates from PryLib's RequestStore into the MainActor,
@@ -34,6 +42,9 @@ public final class RequestStoreWrapper {
         didSet { invalidateFilterCache() }
     }
     public var filterStatus: ClosedRange<UInt>? {
+        didSet { invalidateFilterCache() }
+    }
+    public var filterMockSource: MockSourceFilter = .all {
         didSet { invalidateFilterCache() }
     }
 
@@ -79,6 +90,14 @@ public final class RequestStoreWrapper {
                 guard let code = req.statusCode else { return false }
                 return range.contains(code)
             }
+        }
+        switch filterMockSource {
+        case .all:
+            break
+        case .mocked:
+            result = result.filter { $0.isMock }
+        case .real:
+            result = result.filter { !$0.isMock }
         }
         if !filterText.isEmpty {
             let lower = filterText.lowercased()

--- a/Sources/PryLib/MockEngine.swift
+++ b/Sources/PryLib/MockEngine.swift
@@ -16,11 +16,6 @@ public final class MockEngine {
     /// Find a matching mock. Loose mocks checked first (higher priority).
     public func findMock(path: String, host: String, method: String) -> UnifiedMock? {
         queue.sync {
-            print("[MockEngine] findMock path=\(path) host=\(host) method=\(method) loose=\(looseMocks.count) scenario=\(scenarioMocks.count)")
-            for m in looseMocks + scenarioMocks {
-                let matches = m.matches(path: path, host: host, method: method)
-                print("[MockEngine]   \(matches ? "✅" : "❌") pattern=\(m.pattern) mockHost=\(m.host ?? "nil") mockMethod=\(m.method ?? "nil")")
-            }
             // Loose mocks first (ad-hoc overrides)
             if let mock = looseMocks.first(where: { $0.matches(path: path, host: host, method: method) }) {
                 return mock

--- a/Sources/PryLib/ProjectManager.swift
+++ b/Sources/PryLib/ProjectManager.swift
@@ -202,7 +202,6 @@ public struct ProjectManager {
             }
         }
         MockEngine.shared.loadScenarioMocks(scenarioData.mocks)
-        print("[ProjectManager] Activated \(project)/\(scenario) with \(scenarioData.mocks.count) mocks, MockEngine now has \(MockEngine.shared.count) total")
         for header in scenarioData.headers {
             if header.action == "add", let value = header.value {
                 HeaderRewrite.addRule(name: header.name, value: value)


### PR DESCRIPTION
## Summary

Final polish PR for the project-based mocking system. Completes all open feature issues.

### New in this PR
- **Edit mocks**: Click any mock → editable form with method, status, body, delay, host → Save applies immediately (no deactivate/reactivate)
- **Source filter**: New "Source" dropdown in FilterBar — filter by All / Mocked / Real
- **Device Setup GUI**: New "Device" toolbar button → shows local IP, proxy port, setup server with "Open in Browser"
- **Right-click "Mock this request"**: Now uses UnifiedMock via MockEngine (was broken, using legacy format)
- **Removed debug prints** from MockEngine and ProjectManager
- **Fixed port formatting** (was showing `8,080` with locale separator)

### Issues closed

- Closes #67 — **Scenarios**: Project > Scenario > Mocks hierarchy with activate/deactivate, capture, watchlist per scenario
- Closes #68 — **Compartir escenarios**: ScenarioExporter with export/import `.pryscenario` files (CLI)
- Closes #69 — **Mocking Project**: Organized persistent mocks in `.pry/projects/`, coexists with loose mocks
- Closes #70 — **Status Code Override**: UnifiedMock supports any status code natively (deprecated StatusOverrideStore)
- Closes #71 — **Dispositivos físicos**: DeviceOnboarding HTTP server + GUI with setup page, CA cert download
- Closes #72 — **Recorder**: Record traffic filtered by project domains, convert to mocks with step selection
- Partially addresses #73 — **Background Service**: Phase 1 complete (ProxyState + ProxyGuard orphan detection). Phases 2-3 (daemon + LaunchAgent) pending.

## Test plan

- [x] `swift build` compiles
- [x] `swift test` — 196 tests pass, 0 failures
- [x] CI passed on previous push (build-and-test, build-linux, e2e-test)
- [x] Edit mock → Save → changes apply immediately
- [x] Source filter shows only mocked/real traffic
- [x] Device Setup shows correct IP:port (no formatting issues)
- [x] Right-click → Mock this request → appears in Loose Mocks
- [x] Mock interception works for HTTP and HTTPS (verified with curl + SimulationPry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)