### PR TITLE
feat: PryApp in releases + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Proxy HTTP/HTTPS para iOS devs. Swift puro. Un binario. Sin dependencias externas.</strong>
+  <strong>Proxy HTTP/HTTPS para iOS devs. Swift puro. CLI + GUI nativa macOS. Sin dependencias externas.</strong>
 </p>
 
 <p align="center">
@@ -19,7 +19,7 @@
 
 Existen herramientas excelentes para debuggear tráfico de red — Proxyman, Charles, mitmproxy. Cada una resuelve el problema a su manera y el trabajo que hay detrás merece respeto.
 
-Lo que no existe es una alternativa open source en Swift, liviana, que se integre nativamente en el ecosistema iOS desde la terminal. Sin Python. Sin runtime. Sin UI. Un binario que intercepta, mockea y observa.
+Lo que no existe es una alternativa open source en Swift, liviana, que se integre nativamente en el ecosistema iOS. Sin Python. Sin runtime. Un binario CLI + una app nativa macOS que intercepta, mockea y observa. Testing environment manager para equipos de desarrollo mobile.
 
 ```bash
 pry start
@@ -319,6 +319,50 @@ c → copia al clipboard en el formato seleccionado
 | `Tab` | Alternar entre requests y mocks activos |
 | `Esc` | Limpiar filtro/busqueda |
 | `q` | Salir |
+
+### PryApp — GUI Desktop (macOS)
+
+Pry incluye una app nativa de macOS con interfaz visual completa.
+
+```bash
+# Desde fuente
+swift build --product PryApp
+.build/debug/PryApp
+
+# O descarga PryApp.zip desde GitHub Releases
+```
+
+**Features de la GUI:**
+
+| Feature | Descripcion |
+|---------|-------------|
+| **Project > Scenario > Mocks** | Organiza mocks por proyecto y escenario de testing |
+| **Mock Engine** | Status codes, method matching, headers, delay — todo configurable |
+| **Recorder** | Graba trafico, selecciona requests, convierte a mocks |
+| **Tracking** | Dominios + User-Agents por proyecto, auto-deteccion |
+| **Source Filter** | Filtra trafico por All / Mocked / Real |
+| **Right-click Mock** | Click derecho en request → "Mock this request" |
+| **Device Setup** | Servidor de setup para dispositivos fisicos (QR + instrucciones) |
+| **Export/Import** | Comparte escenarios como `.pryscenario` con tu equipo |
+| **Crash Recovery** | Detecta proxy huerfano y restaura internet automaticamente |
+
+**Toolbar:**
+
+```
+[Start/Stop] [Clear] [Mocking] [Breakpoints] [Rules] [Device]
+```
+
+**Sidebar:** Agrupa trafico por app + muestra configuracion activa (proyecto, mocks, breakpoints).
+
+**Workflow tipico:**
+
+1. Crea un proyecto ("MiApp") con dominios a trackear
+2. Crea un escenario ("Happy Path") dentro del proyecto
+3. Graba trafico real → selecciona requests → convierte a mocks
+4. Activa el escenario → todos los mocks interceptan automaticamente
+5. Cambia a otro escenario ("Error Testing") con un click
+
+---
 
 ### App de testing (iOS Simulator)
 


### PR DESCRIPTION
## Summary

- Updated README with PryApp desktop GUI documentation (features, workflow, toolbar)
- PryApp.app bundle included in GitHub Releases (from PR #78)
- Fix: ProjectManager tests no longer delete user projects (from PR #78)

## Release

This PR has the `minor` label to trigger a release with PryApp.app included.

### What's in the release:
- `pry-universal` — CLI binary (arm64 + x86_64)
- `PryApp.zip` — macOS app bundle (arm64 + x86_64)

### Install GUI:
1. Download `PryApp.zip` from release assets
2. Unzip → move `PryApp.app` to `/Applications/`
3. First launch: right-click → Open

🤖 Generated with [Claude Code](https://claude.com/claude-code)