### PR TITLE
docs+tooling: ADR-006 + Claude skills/agent para arquitectura PryApp

### DIFF
--- a/.claude/agents/arch-reviewer.md
+++ b/.claude/agents/arch-reviewer.md
@@ -1,0 +1,154 @@
+---
+name: arch-reviewer
+description: Review a PR/diff against the PryApp architecture rules defined in ADR-006. Flags violations with file:line. Run before opening a PR.
+model: haiku
+tools: Read, Glob, Grep, Bash
+---
+
+# arch-reviewer — Guardrail de arquitectura y TDD para PryApp
+
+Sos un reviewer especializado en las reglas del [ADR-006](../../docs/ADR-006-new-architecture-desktop-app.md) de Pry. Tu única tarea es validar que un diff o un PR respete las reglas. No refactorizás vos — sólo reportás lo que está mal para que el humano decida.
+
+## Entrada
+
+El usuario te pasa uno de:
+- Un diff (via `git diff main...HEAD` o similar)
+- Un número de PR (usás `gh pr diff <n>` para leerlo)
+- Un conjunto de archivos modificados
+
+Si no te aclara cuál, corré `git diff main...HEAD --stat` en el repo para ver qué hay.
+
+## Reglas a validar
+
+Chequeás las siguientes **en orden**. Cada violación la reportás como:
+
+```
+[CATEGORÍA] <archivo>:<línea> — <explicación corta>
+  sugerencia: <qué hacer>
+```
+
+### Regla 1 — Cero singletons nuevos (SCOPE: PryApp)
+
+Buscá en los archivos **nuevos o modificados** dentro de `Sources/PryApp/`:
+
+```bash
+grep -n "static let shared\|static var shared" <archivos-modificados>
+```
+
+Si aparece en código nuevo de PryApp → violación. Los singletons legacy (`MockEngine.shared`, etc.) están permitidos sólo si se consumen desde un `Store` como adapter temporal — marcalo como "coexistencia" (no violación) pero loguealo en un warning.
+
+### Regla 2 — Layering: Views no importan PryLib directo
+
+Para cada `.swift` agregado o modificado bajo `Sources/PryApp/Features/` o `Sources/PryApp/`:
+
+```bash
+grep -n "^import PryLib" <archivo>
+```
+
+Si aparece → violación. Views y Stores deben consumir tipos de `PryApp/Core/`, no de PryLib. Excepción: `Sources/PryApp/Core/AppCore.swift` puede importar PryLib para puentear types temporalmente.
+
+### Regla 3 — Feature structure
+
+Si hay archivos agregados en `Sources/PryApp/Features/<X>/`, verificar que:
+- Existe `<X>Store.swift` (o bien nombrado como `<X>Repository.swift`)
+- Si la feature muta el flow: existe `<X>Interceptor.swift`
+- Existe `<X>View.swift` (si tiene UI)
+- Existen tests correspondientes en `Tests/PryAppTests/Features/<X>/` o `Tests/PryLibTests/Features/<X>/`
+
+Si faltan archivos → violación. Si sobran archivos (ej. dos `Store` en un folder) → violación.
+
+### Regla 4 — Interceptor protocol compliance
+
+Para cada `<X>Interceptor.swift`:
+- Declara `phase: Phase` con un valor explícito (no default)
+- Implementa `intercept(_ ctx: RequestContext) async -> InterceptResult`
+- No tiene `Task { @MainActor in … }` dentro de `intercept` sin razón (preferir `await MainActor.run`)
+- No llama a `.shared` de nada de PryLib
+
+### Regla 5 — Store protocol compliance
+
+Para cada `<X>Store.swift`:
+- Está marcado `@Observable @MainActor`
+- Es `final class`
+- Recibe dependencies por init (al menos `EventBus` si suscribe)
+- Persiste a un path de `StoragePaths` (no hardcoded)
+- Métodos mutating publican evento al bus si hay consumidores externos posibles
+
+### Regla 6 — TDD compliance
+
+Por cada método público agregado o modificado en `<X>Store.swift` o `<X>Interceptor.swift`, verificar que hay al menos un test que lo cubra:
+
+```bash
+# para cada método público X:
+grep -rn "X(" Tests/
+```
+
+- Si el método no tiene test → violación TDD.
+- Si el test file está **antes** que el impl file en el commit (usando `git log --oneline --diff-filter=A -- <files>`) → ✓ buena práctica.
+- Si los tests tocan `~/.pry/` real (grep por `NSHomeDirectory\|/.pry/\|StoragePaths\.` en test files sin override) → violación.
+- Si encontrás `XCTAssertTrue(true)` o `XCTAssertNotNil(thing)` sin asserts específicos → violación (placeholder test).
+
+### Regla 7 — Build warnings nuevos
+
+```bash
+swift build 2>&1 | grep -iE "warning:" | diff <previous-baseline> -
+```
+
+Si aparecen warnings nuevos respecto al baseline (main) → violación. Incluye `@unchecked Sendable` nuevo, fuerzas `as!` nuevos, `!` force unwrap en código que no es prototype.
+
+### Regla 8 — Doc comments en público nuevo
+
+Cada tipo/método `public` nuevo debe tener `///` docstring. No es obligatorio para internos. Si falta → warning (no violación dura).
+
+### Regla 9 — Previews para views nuevas
+
+Cada `Sources/PryApp/Features/<X>/<X>View.swift` nuevo debe tener al menos un `#Preview`. Si no → violación.
+
+### Regla 10 — Sin imports innecesarios
+
+Grep por `import NIO`, `import NIOSSL` en archivos de `Sources/PryApp/Features/` — si aparecen, violación (esas deps son de PryLib, no deben trepar a la capa de features).
+
+## Formato de salida
+
+Al terminar, imprimir resumen:
+
+```
+arch-reviewer: X violations found
+
+[CRÍTICO]
+- [SINGLETON] Sources/PryApp/Features/Mocking/MockStore.swift:42 — introduce static let shared
+  sugerencia: quitá el singleton, inyectá el store via AppCore
+
+- [TDD] Sources/PryApp/Features/Mocking/MockStore.swift:58 — método `resolve()` sin test
+  sugerencia: agregá test en Tests/PryAppTests/Features/Mocking/MockStoreTests.swift
+
+[WARNING]
+- [DOCS] Sources/PryApp/Features/Mocking/MockStore.swift:12 — tipo público sin ///
+  sugerencia: agregá doc comment arriba de `public final class MockStore`
+
+✓ Layering: OK
+✓ Interceptor compliance: OK
+✓ Warnings de build: baseline mantenido
+```
+
+Si no hay violaciones:
+
+```
+arch-reviewer: ✓ PR cumple con ADR-006 y disciplina TDD.
+```
+
+## Principios de review
+
+- **Objetivo, no estético**: no critiques estilo si no rompe una regla. El formateo lo hace swift-format.
+- **Un reporte por archivo**: si un archivo rompe 3 reglas, listalas todas junto al archivo.
+- **No auto-fix**: tu output es un reporte de texto, no un diff. El humano decide qué arreglar.
+- **No assume context**: si el diff no tiene suficiente info (ej. no ves el archivo de tests), pedile al usuario que te pase más.
+- **Rápido**: usá `haiku` model por una razón — esta tarea es deterministic. No overthink.
+
+## Cuándo NO aplicar reglas
+
+- Archivos bajo `Sources/PryLib/` → están fuera de scope (legacy, no sigue el ADR)
+- Archivos bajo `Sources/Pry/` → CLI, fuera de scope
+- Archivos bajo `Sources/PryLib/TUI/` → TUI, fuera de scope
+- PRs marcados `docs:` que sólo tocan Markdown → skip todas las reglas técnicas
+- Changes a `docs/` y `.claude/` → skip regla 7 (build warnings), el resto tampoco aplica

--- a/.claude/skills/new-feature/SKILL.md
+++ b/.claude/skills/new-feature/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: new-feature
+description: Scaffold a new PryApp feature following the ADR-006 architecture (Store + Interceptor + View) with TDD-first tests
+---
+
+# /new-feature — Scaffold a feature (TDD-first)
+
+## Visión
+
+Cada feature de PryApp sigue el patrón establecido en [ADR-006](../../../docs/ADR-006-new-architecture-desktop-app.md): un folder con 3 archivos (`Store`, `Interceptor`, `View`) más sus tests. Este skill automatiza la creación respetando la disciplina **TDD obligatoria**: tests primero, código después.
+
+## Cuándo usar
+
+- Migrar una feature legacy de `PryLib/*.swift` al nuevo patrón
+- Agregar una feature completamente nueva
+- Ejemplos válidos: Blocking, MapRemote, DNSOverrides, HeaderRules, Throttling, Mocking, Breakpoints
+
+## Cuándo NO usar
+
+- Cambios puntuales dentro de una feature existente → usa `/tdd` en su lugar
+- Features que no mutan el flow Y no tienen UI (ej. utility puro) → no aplica este patrón
+
+## Entrada que necesito del usuario
+
+Antes de generar archivos, preguntarle al usuario:
+
+1. **Nombre de la feature** (PascalCase, ej. `Blocking`, `MapRemote`)
+2. **¿Qué hace el Interceptor?** (uno de):
+   - `gate` — bloquea o deja pasar (BlockList, allowlist)
+   - `resolve` — reemplaza la response (Mock, MapLocal)
+   - `transform` — modifica request/response (HeaderRewrite, Rules)
+   - `network` — cambia destino/timing (Throttle, DNS)
+   - `none` — feature solo observa, no muta (sólo tiene Store + View, sin Interceptor)
+3. **¿Qué comportamiento clave del Store quiero testear?** (lista de 2-4 behaviors, ej. "add domain, remove domain, isBlocked matches wildcard, persists across reload")
+4. **¿Qué branches del Interceptor testear?** (pass, shortCircuit, transform, pause)
+
+## Qué genero
+
+### 1. Tests PRIMERO (RED)
+
+Crear archivos en orden, con asserts reales que fallarán al correr:
+
+```
+Tests/PryAppTests/Features/{Name}/
+├── {Name}StoreTests.swift
+└── {Name}InterceptorTests.swift   (si aplica)
+```
+
+Cada test usa fakes (`InMemoryEventBus`, `TempDirFileStorage`), nunca toca `~/.pry/` real. Cada test tiene `XCTAssertEqual` o `#expect` con valores esperados concretos — no `XCTAssertTrue(true)` placeholders.
+
+### 2. Implementación stub (mantiene RED)
+
+Crear archivos con stubs que hagan fallar los tests por **assertion**, no por compile:
+
+```
+Sources/PryApp/Features/{Name}/
+├── {Name}Store.swift         — propiedades + métodos con fatalError("TODO RED")
+├── {Name}Interceptor.swift   — intercept() retorna .pass con fatalError comentado
+└── {Name}View.swift          — SwiftUI mínimo que compila + #Preview con fake store
+```
+
+### 3. Registro en AppCore
+
+Agregar al final de `Sources/PryApp/Core/AppCore.swift` init:
+- Instanciar el Store
+- Registrar el Interceptor en `interceptors` (si aplica)
+
+### 4. Verificar RED
+
+Correr:
+```bash
+swift test --filter {Name}
+```
+
+Mostrar al usuario la salida: debe aparecer al menos 1 test FAIL. Ese es el punto de partida correcto del ciclo TDD.
+
+## Convenciones específicas del template
+
+### {Name}Store.swift
+
+```swift
+import Foundation
+
+@Observable @MainActor
+public final class {Name}Store {
+    // MARK: - State
+    public private(set) var items: [{ItemType}] = []
+
+    // MARK: - Dependencies
+    private let storagePath: String
+    private let bus: EventBus
+
+    // MARK: - Init
+    public init(storagePath: String = StoragePaths.{someFile}, bus: EventBus) {
+        self.storagePath = storagePath
+        self.bus = bus
+        reload()
+    }
+
+    // MARK: - Actions
+    public func add(_ item: {ItemType}) {
+        fatalError("TODO RED: implement add")
+    }
+
+    // ... more methods as RED stubs
+
+    // MARK: - Persistence
+    private func reload() {
+        // leer de storagePath
+    }
+
+    private func persist() {
+        // escribir a storagePath
+    }
+}
+```
+
+### {Name}Interceptor.swift
+
+```swift
+import Foundation
+
+public struct {Name}Interceptor: Interceptor {
+    public let phase: Phase = .{gateOrResolveOrTransformOrNetwork}
+    private let store: {Name}Store
+
+    public init(store: {Name}Store) {
+        self.store = store
+    }
+
+    public func intercept(_ ctx: RequestContext) async -> InterceptResult {
+        fatalError("TODO RED: implement intercept logic")
+    }
+}
+```
+
+### {Name}View.swift
+
+```swift
+import SwiftUI
+
+struct {Name}View: View {
+    @Environment(AppCore.self) private var core
+
+    var body: some View {
+        Text("{Name} — TODO")
+    }
+}
+
+#Preview("empty") {
+    {Name}View()
+        .environment(AppCore.preview())
+}
+
+#Preview("with data") {
+    {Name}View()
+        .environment(AppCore.preview(seed: .{name}Sample))
+}
+```
+
+### {Name}StoreTests.swift
+
+Un `XCTestCase` por cada behavior que pidió el usuario. Usar fakes. Setup/teardown con temp dir.
+
+```swift
+import XCTest
+@testable import PryApp
+
+final class {Name}StoreTests: XCTestCase {
+    var store: {Name}Store!
+    var bus: EventBus!
+    var tempDir: URL!
+
+    override func setUp() async throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        bus = EventBus()
+        store = await {Name}Store(
+            storagePath: tempDir.appendingPathComponent("store").path,
+            bus: bus
+        )
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    @MainActor
+    func test_add_appendsToItems() throws {
+        // GIVEN
+        XCTAssertTrue(store.items.isEmpty)
+        // WHEN
+        store.add(.sample)
+        // THEN — deliberadamente falla hasta implementar add()
+        XCTAssertEqual(store.items.count, 1)
+    }
+
+    // ... más tests por cada behavior
+}
+```
+
+### {Name}InterceptorTests.swift
+
+```swift
+import XCTest
+@testable import PryApp
+
+final class {Name}InterceptorTests: XCTestCase {
+    func test_phase_is{Expected}() {
+        let store = {Name}Store(/* fakes */)
+        let sut = {Name}Interceptor(store: store)
+        XCTAssertEqual(sut.phase, .{expected})
+    }
+
+    func test_pass_when{Condition}() async {
+        // arrange, act, assert
+    }
+
+    func test_shortCircuit_when{Condition}() async {
+        // ...
+    }
+}
+```
+
+## Después del scaffold
+
+Al usuario le decís:
+
+1. "Tests corren en RED — mostrame la salida para verificar"
+2. "Implementá método por método, corriendo `swift test --filter {Name}` entre cada uno"
+3. "Cuando todo esté GREEN, corré `Agent({ subagent_type: 'arch-reviewer' })` antes del PR"
+
+## Archivos a leer para tener contexto
+
+Antes de generar, leer (si existen):
+- `docs/ADR-006-new-architecture-desktop-app.md` — la fuente de verdad del patrón
+- `Sources/PryApp/Core/Interceptor.swift` — protocolo a implementar
+- `Sources/PryApp/Core/AppCore.swift` — para saber dónde registrar
+- `Sources/PryApp/Features/Blocking/` — si existe, es el template validado de referencia
+- `Sources/PryLib/StoragePaths.swift` — para elegir/agregar el path correcto
+
+Si alguno no existe (ej. todavía estamos en Paso 1 del milestone y no se creó Core/), avisar al usuario que es prerequisito.
+
+## Principios no negociables
+
+- Tests van PRIMERO en el commit (diff muestra el test file antes que el impl file)
+- Nunca tocar `~/.pry/` real en tests — siempre temp dir
+- Stubs usan `fatalError("TODO RED: ...")`, nunca devuelven valores falsos que hagan pasar los tests
+- Todo archivo nuevo tiene doc comment (`///`) en la declaración pública
+- `Sources/PryApp/Core/` existe antes de correr este skill — si no, abortar y pedirle al usuario que primero arme el scaffolding del Paso 1

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: tdd
+description: Pair programming TDD cycle (RED → GREEN → REFACTOR) para cambios dentro de una feature existente de PryApp
+---
+
+# /tdd — Pair programming TDD dentro de una feature
+
+## Visión
+
+Cuando ya hay una feature armada con `/new-feature` y querés **agregar un comportamiento nuevo** (o arreglar un bug, o refactorizar), este skill conduce el ciclo RED-GREEN-REFACTOR de forma explícita.
+
+La diferencia con `/new-feature`: este no crea archivos. Edita los existentes siguiendo el ciclo.
+
+## Cuándo usar
+
+- Agregar un método nuevo a un Store existente
+- Agregar una rama nueva en un Interceptor existente
+- Arreglar un bug (regression test primero, fix después)
+- Refactor con seguridad (tests pasan antes y después)
+
+## Cuándo NO usar
+
+- Crear una feature nueva desde cero → usa `/new-feature`
+- Cambios puramente cosméticos en la UI (renombre de texto, color) → directo sin TDD
+- Cambios en archivos de documentación → no aplica
+
+## Entrada del usuario
+
+`/tdd <qué querés hacer>` — ej. `/tdd BlockStore soporta wildcards con *.example.com`
+
+Si el mensaje es vago, preguntar:
+- ¿En qué archivo? (Store, Interceptor, View, o varios)
+- ¿Qué comportamiento nuevo esperás? (describilo como test: "dado X, cuando Y, entonces Z")
+- ¿Rompe algún test existente? Si sí, ¿hay que actualizarlo o es regresión?
+
+## Ciclo
+
+### 1. RED — escribir el test primero
+
+Editar el archivo de tests correspondiente. Agregar **un solo test** que exprese el comportamiento nuevo. Asserts reales, no placeholders.
+
+```swift
+func test_isBlocked_withWildcardPattern_matchesSubdomain() {
+    // GIVEN
+    store.add("*.example.com")
+    // WHEN
+    let result = store.isBlocked("api.example.com")
+    // THEN
+    XCTAssertTrue(result)
+}
+```
+
+Correr el test:
+```bash
+swift test --filter <TestClass>/<testMethod>
+```
+
+**Esperar**: FAIL. Si pasa de entrada, el test está mal (no prueba nada nuevo) — mostrar al usuario y replantear.
+
+Mostrar la salida al usuario y decir: "✓ RED confirmado. Listo para implementar?"
+
+### 2. GREEN — implementación mínima
+
+Editar el archivo de producción. Implementar **lo mínimo** para que el test pase. No agregar features adicionales. No optimizar todavía.
+
+Correr el test:
+```bash
+swift test --filter <TestClass>/<testMethod>
+```
+
+**Esperar**: PASS. Correr también toda la suite de la feature para confirmar que no rompimos nada:
+```bash
+swift test --filter <FeatureName>
+```
+
+Si algún test existente rompió, parar y analizar con el usuario antes de continuar.
+
+Mostrar salida: "✓ GREEN. ¿Refactorizamos o seguimos con otro test?"
+
+### 3. REFACTOR — mejorar con red de seguridad
+
+Preguntar al usuario: "¿Ves algo para mejorar en el código nuevo o existente? Si querés, revisaré yo."
+
+Si hay refactor claro (extraer función, renombrar, eliminar duplicación), proponerlo como diff. Después de cada refactor:
+```bash
+swift test --filter <FeatureName>
+```
+
+Tests deben seguir GREEN. Si no, revertir.
+
+## Reglas
+
+- **Un test a la vez**. No generar 5 tests de golpe. Cycle uno por uno.
+- **El test siempre se commitea antes de la implementación** si el usuario hace commits granulares. Para un commit único, orden dentro del diff: test file primero.
+- **Nunca** escribir código que no responda a un test fallado.
+- **Siempre** correr `swift test` para confirmar transiciones. No asumir.
+- **Nunca** tocar `~/.pry/` real en tests. Usar temp dirs y fakes.
+
+## Salida típica al usuario
+
+```
+[RED]
+swift test --filter BlockStoreTests/test_isBlocked_withWildcardPattern_matchesSubdomain
+→ Test Case '-[BlockStoreTests test_isBlocked_withWildcardPattern_matchesSubdomain]' failed
+  XCTAssertTrue failed - 0 != 1
+
+✓ Confirmado en RED. Implemento `isBlocked` para soportar wildcards?
+
+[GREEN]
+swift test --filter BlockStore
+→ Test Suite 'BlockStoreTests' passed
+
+✓ GREEN (8/8 tests pasan). ¿Refactor o seguimos con el siguiente behavior?
+```
+
+## Archivos a leer para contexto
+
+- El archivo de la feature que se va a modificar (`Sources/PryApp/Features/{X}/`)
+- Los tests existentes de esa feature (`Tests/PryAppTests/Features/{X}/`)
+- `docs/ADR-006-new-architecture-desktop-app.md` solo si el cambio involucra el patrón Interceptor/EventBus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,37 @@
 - Proxy HTTP/HTTPS selectivo — no rompe apps que no le pidas interceptar
 - Documentacion en español, estilo libro tecnico
 
+## Arquitectura PryApp (GUI) — ADR-006
+
+La GUI de macOS sigue una arquitectura nueva documentada en [docs/ADR-006-new-architecture-desktop-app.md](./docs/ADR-006-new-architecture-desktop-app.md). Tres conceptos:
+
+1. **Interceptor** (`Sources/PryApp/Core/Interceptor.swift`) — features que mutan el flow del proxy (Block, Mock, Breakpoint, etc.). Implementan un protocolo único ordenado por `Phase`.
+2. **EventBus** (`Sources/PryApp/Core/EventBus.swift`) — observers consumen `AsyncStream<Event>` sin mutar el flow (UI, Recorder, métricas).
+3. **FeatureStore** (`Sources/PryApp/Features/<X>/<X>Store.swift`) — un `@Observable @MainActor` por feature que combina repo + viewmodel.
+
+**Scope**: sólo PryApp. CLI y TUI siguen usando singletons legacy — NO tocar.
+
+**Coexistencia**: GUI y CLI/TUI comparten archivos en `~/.pry/` via `StoragePaths`. Nunca corren simultáneamente.
+
+### TDD obligatorio para features nuevas
+
+Todo código nuevo bajo `Sources/PryApp/Features/` sigue RED → GREEN → REFACTOR:
+
+1. Escribir el(los) test(s) fallando primero (`Tests/PryAppTests/Features/<X>/`)
+2. Correr `swift test --filter <X>` → confirmar **RED**
+3. Implementar lo mínimo para pasar → **GREEN**
+4. Refactorizar manteniendo GREEN
+
+Los tests **nunca** tocan `~/.pry/` real — usan temp dirs y fakes (`InMemoryEventBus`, etc.).
+
+### Tooling de workflow
+
+- **`/new-feature <Name>`** — scaffoldea folder completo (Store + Interceptor + View + tests) en estado RED. Ver `.claude/skills/new-feature/SKILL.md`.
+- **`/tdd <qué>`** — pair programming RED-GREEN-REFACTOR dentro de una feature existente. Ver `.claude/skills/tdd/SKILL.md`.
+- **`arch-reviewer` agent** — antes de abrir PR, correr `Agent({ subagent_type: "arch-reviewer" })` para validar contra las reglas del ADR. Ver `.claude/agents/arch-reviewer.md`.
+
+Estos tres refuerzan las reglas de arquitectura + TDD automáticamente. Úsalos.
+
 ## Stack
 
 - **CLI**: Swift 5.9+, macOS 13+, SPM

--- a/docs/ADR-006-new-architecture-desktop-app.md
+++ b/docs/ADR-006-new-architecture-desktop-app.md
@@ -1,0 +1,186 @@
+# ADR-006 — Nueva arquitectura para PryApp (macOS desktop)
+
+- **Status**: Accepted
+- **Fecha**: 2026-04-15
+- **Alcance**: solo `PryApp` (GUI). `Pry` (CLI) y `PryLib/TUI` no se tocan.
+- **ADRs previos** (como issues cerrados): #23 (ADR-001 SwiftUI+AppKit), #24 (ADR-002 3 capas), #25 (ADR-003 system proxy), #26 (ADR-004 distribución), #46 (ADR-005 MVVM iOS).
+
+---
+
+## Contexto
+
+Tras varios meses de iteración rápida sobre PryApp, una auditoría interna detectó problemas que frenan tanto el mantenimiento como la adopción de contributors externos:
+
+- **6 singletons** con estado mutable compartido entre event loops de NIO y `@MainActor` (`MockEngine.shared`, `Recorder.shared`, `BreakpointStore.shared`, `RequestBreakpoint.shared`, `OutputBroker.shared`, `RequestStore.shared`). Races reconocidas en comentarios del propio código (ej. `BreakpointUIManager.onPause` admite que GUI+TUI concurrentes pierden notificaciones).
+- **Files monolíticos**: `UnifiedMockView.swift` (1,181 LOC), `Pry/main.swift` (1,183 LOC) bloquean cualquier cambio simple.
+- **Layering violado**: 66% de las views de `PryApp` importan `PryLib` directo en vez de ir por `PryKit`. Cambiar un tipo en PryLib implica tocar views.
+- **DI ausente**: todo es concreto e instanciado a `@State` en `PryApp.swift:11-16`. Imposible mockear para tests o previews. **Cero `#Preview`** en 38 archivos de view.
+- **Reactivity imperativa**: managers llaman `reload()` manual tras mutar, sin publishers/streams. El callback único de breakpoints sólo admite un subscriber (GUI o TUI, no ambos).
+- **Tests dependen del filesystem real** (`~/.pry/`) — riesgo de flakiness.
+
+Agregar una feature nueva toca ~5 archivos en 3 módulos, y cada feature adicional amplifica los problemas. La barrera para contribuir es alta, y para el mantenedor individual ya empieza a ser friccional.
+
+---
+
+## Decisión
+
+Diseñar e introducir una arquitectura nueva **solo en `PryApp`**, basada en tres conceptos minimalistas y ortogonales. CLI/TUI se quedan como están.
+
+### 1. Interceptor chain
+
+Un protocolo único que describe cómo cada feature puede **mutar el flow** del proxy. Ejecución ordenada por `phase`:
+
+```swift
+protocol Interceptor: Sendable {
+    var phase: Phase { get }
+    func intercept(_ ctx: RequestContext) async -> InterceptResult
+}
+
+enum Phase: Int, Comparable {
+    case gate = 0        // BlockList, allowlists
+    case resolve = 1     // Mock, MapLocal (short-circuit antes de la red)
+    case transform = 2   // HeaderRewrite, Rules (muta request saliente)
+    case network = 3     // Throttle, DNSSpoofing, MapRemote (modifica destino o timing)
+}
+
+enum InterceptResult {
+    case pass
+    case transform(RequestContext)
+    case shortCircuit(Response)
+    case pause(resolution: () async -> InterceptResult)
+}
+```
+
+Cada feature que muta el flow se implementa como un `struct` conforme a `Interceptor`. La `InterceptorRegistry` (un `actor`) mantiene el orden y permite `register`/`unregister` en runtime (enable/disable sin reiniciar).
+
+### 2. EventBus (observers via AsyncStream)
+
+Un `actor EventBus` que publica eventos del ciclo de vida del proxy (`RequestCaptured`, `ResponseReceived`, `RequestPaused`, `TrafficCleared`, `TunnelOpened`, etc.). Cualquier cantidad de subscribers consume via `AsyncStream`:
+
+```swift
+let stream = core.bus.subscribe()
+for await event in stream {
+    // UI, recorder, métricas, TUI externa... cada uno su copia
+}
+```
+
+- **Zero callbacks únicos**: N subscribers simultáneos sin pisarse.
+- **Subscribe/unsubscribe natural**: cancelar el `Task` termina el stream y limpia recursos.
+- **Buffered + drop-oldest** por default — el proxy nunca se bloquea si un consumer es lento.
+- **Body lazy**: eventos llevan `id + headers`. El body se pide on-demand via referencia, evitando copias innecesarias.
+
+Los observers **no pueden mutar** el flow. Si una feature necesita mutar → es un Interceptor. Si sólo observa → suscribe al bus. Esa separación es invariante.
+
+### 3. Feature store (`@Observable @MainActor`)
+
+Cada feature encapsula su state + persistence + actions en un único objeto:
+
+```swift
+@Observable @MainActor
+final class BlockStore {
+    var domains: [String]
+    private let bus: EventBus
+    // add/remove/clear/isBlocked + persist
+}
+```
+
+- **Combina repo + viewmodel**: evita capas de wrapping innecesarias.
+- **Inyectado via `@Environment`** a las views.
+- **Previews triviales**: una factory que retorna un store con data fake.
+- **Suscribe al bus** si necesita eventos.
+- **Interceptors leen del store** via `MainActor.run` cuando corren en NIO thread (1 línea).
+
+### Composition root
+
+`PryApp.swift` instancia un solo objeto `AppCore` (`@Observable @MainActor`) que arma `bus`, `interceptors`, y las stores. Lo inyecta via `.environment(core)`. Las features acceden via `@Environment(AppCore.self)`.
+
+### Organización física
+
+```
+Sources/PryApp/
+├── Core/                    # protocolos + bus + AppCore + Events
+├── Features/
+│   ├── Blocking/            # BlockStore + BlockInterceptor + BlocksView
+│   ├── Mocking/             # MockStore + MockInterceptor + MocksView
+│   └── ...                  # un folder por feature, 2-3 archivos
+├── Shared/                  # componentes reutilizables
+└── PryApp.swift             # @main
+```
+
+Una feature completa = un folder con ~3 archivos de ~100 LOC. Template copiable, trivial para IA y contributors.
+
+---
+
+## Coexistencia con el código viejo
+
+**CLI/TUI intocables.** Siguen usando `BlockList.shared`, `MockEngine.shared`, etc. Siguen imprimiendo a `OutputBroker.shared.log`.
+
+**Filesystem como contrato**: los nuevos stores escriben a los **mismos archivos** en `~/.pry/` que los legacy (via `StoragePaths`). CLI y GUI leen la misma data. Nunca corren simultáneamente (el proxy escucha en el mismo puerto), así que no hay carrera de runtime.
+
+**Estrategia**: strangler fig. Se agrega la arquitectura nueva al lado del código viejo. Se migra una feature por vez. Durante meses PryApp queda "híbrida" (parte vieja, parte nueva) — aceptable y deseable, porque cada PR es chico y revertible.
+
+Cuando todas las features migran, los singletons originales quedan sin consumers dentro de PryApp y se pueden deprecar (no eliminar — CLI sigue usándolos).
+
+---
+
+## Consecuencias
+
+### Ganancias
+
+- **Testabilidad**: stores y interceptors testeables con fakes. Views testeables con previews.
+- **Contributor-friendliness**: agregar feature = copiar folder, modificar 3 archivos. Documentable en CONTRIBUTING.md con ejemplo concreto.
+- **Zero races**: actors isolated + MainActor stores + AsyncStream. `@unchecked Sendable` desaparece de código nuevo.
+- **Observabilidad**: múltiples subscribers del bus (UI + futura telemetría + export + whatever) sin pisarse.
+- **Features aisladas**: un bug en mocking no toca blocking. Interceptor A no conoce interceptor B.
+- **Enable/disable en runtime**: registry permite prender/apagar features sin reiniciar el proxy.
+
+### Trade-offs
+
+- **Fase híbrida larga**: durante la migración PryApp tiene dos patrones coexistiendo. Mitigación: cada PR entrega una feature migrada, nunca se bloquea la app.
+- **`@MainActor` stores**: interceptors en NIO thread necesitan `await MainActor.run { store.method() }` para leer. Una línea extra, costo ínfimo.
+- **Curva de entrada**: contributors nuevos deben entender `actor`, `AsyncStream`, `@Observable`. Mitigación: template + ejemplo + CONTRIBUTING.md reducen esto a 30 min de lectura.
+- **Más archivos por feature**: 3 chicos en vez de 1 mediano. Net positivo para mantenibilidad; neutro para navegación.
+
+### Explícitamente fuera de scope
+
+- **CLI** (`Sources/Pry/main.swift`) — no se toca en esta refactorización.
+- **TUI** (`Sources/PryLib/TUI/`) — no se toca.
+- **Network Extension** (issue #86) — ortogonal, se beneficia de esta arquitectura cuando llegue pero no es prerequisito.
+- **Cambios en `Package.swift`** — se mantienen los 4 targets actuales. Nada de módulos SPM por feature.
+- **Dependencias externas** — se mantiene la filosofía "Swift puro + NIO".
+
+---
+
+## Plan de rollout
+
+### Milestone 1 — Bases (cubierto por este PR + dos más)
+
+1. **Paso 0** (este PR): este ADR como documentación.
+2. **Paso 1**: scaffolding de `Sources/PryApp/Core/` con los protocolos + `EventBus` + `AppCore` vacío. Sin conectar al flujo actual. Código nuevo inerte.
+3. **Paso 2**: migrar `BlockList` (45 LOC, la más simple) como proof-of-concept. Se crea `Sources/PryApp/Features/Blocking/` con `BlockStore` + `BlockInterceptor` + `BlocksView` + tests + previews. El pipeline real del proxy todavía usa el legacy `BlockList.isBlocked` — sólo la GUI empieza a usar el path nuevo.
+
+### Milestone 2
+
+4. Integrar la `InterceptorRegistry` en `HTTPInterceptor` y `ConnectHandler` (reemplaza call sites legacy de `BlockList` por la chain nueva).
+5. Migrar `MapRemote` siguiendo el template validado.
+6. Documentar el proceso en `CONTRIBUTING.md` con ejemplo paso a paso.
+
+### Milestone 3+ (un PR por feature)
+
+7. `DNSSpoofing` → `Features/DNSOverrides/`
+8. `StatusOverrideStore` → `Features/StatusOverrides/`
+9. `HeaderRewrite` → `Features/HeaderRules/`
+10. `Recorder` → `Features/Recordings/`
+11. `Breakpoints` → `Features/Breakpoints/` (con `BreakpointCoordinator` actor para manejar pausa/resume con continuations)
+12. `Mocking` → `Features/Mocking/` (el más grande, al final, con aprendizaje acumulado)
+
+Cada paso es un PR merged antes del siguiente. Revertible individualmente.
+
+---
+
+## Referencias
+
+- [Auditoría interna](../.claude/plans/parallel-sniffing-seal.md) (histórica — será reemplazada por otros planes)
+- Issues relacionados: #73 (Background Service), #84 (Watchdog), #86 (Network Extension) — todos compatibles con esta arquitectura
+- [Apple: `@Observable`](https://developer.apple.com/documentation/Observation)
+- [Swift concurrency proposal SE-0306 (Actors)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)


### PR DESCRIPTION
## Summary

Milestone 1 — Paso 0: establecer la decisión arquitectónica + dejar la tooling de Claude lista para usarse desde el primer día de migración.

## Contenido

### 📘 docs/ADR-006-new-architecture-desktop-app.md

ADR documentando la nueva arquitectura de PryApp:

- **Interceptor chain** — features que mutan el flow (Block, Mock, Breakpoint, etc.)
- **EventBus** — observers suscriben via \`AsyncStream\` sin mutar
- **FeatureStore** — un \`@Observable @MainActor\` por feature (repo + viewmodel)
- Coexistencia con CLI/TUI (comparten archivos en \`~/.pry/\`)
- Rollout strangler fig por milestones

### 🛠 Tooling de Claude

- **\`.claude/skills/new-feature/SKILL.md\`** — slash command \`/new-feature <Name>\` scaffoldea un folder completo (Store + Interceptor + View + tests) en estado RED para arrancar TDD.
- **\`.claude/skills/tdd/SKILL.md\`** — slash command \`/tdd <qué>\` conduce ciclo RED-GREEN-REFACTOR dentro de una feature existente.
- **\`.claude/agents/arch-reviewer.md\`** — sub-agent (haiku) que valida diffs/PRs contra las 10 reglas del ADR-006 antes de abrir PR. Reporta violaciones con file:line.

### 📝 CLAUDE.md

Sección nueva documentando la arquitectura PryApp, disciplina TDD obligatoria, y cómo invocar las 3 herramientas.

## Por qué en el mismo PR

Al mergear, la migración arranca con:
- la decisión documentada (ADR),
- la tooling que automatiza el patrón correcto (skills + agent),
- y las reglas en CLAUDE.md que toda instancia futura de Claude va a leer.

Sin esto, el primer feature a migrar (Blocking en el siguiente PR) tendría que inventar el template. Con esto, \`/new-feature Blocking\` lo hace solo.

## No incluye

- Código de producción (Core/ scaffolding viene en el próximo PR)
- Primera feature migrada (Blocking viene en el PR después)

## Release

Sin label — este PR no dispara release. Solo docs + tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)