### PR TITLE
refactor(PryApp): Core scaffolding ADR-006 (Paso 1 de 3)

### DIFF
--- a/Sources/PryApp/Core/AppCore.swift
+++ b/Sources/PryApp/Core/AppCore.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Observation
+
+/// Composition root de la arquitectura nueva de PryApp (ADR-006).
+///
+/// Vive en `@State` en `PryApp.swift` e se inyecta al árbol de views via
+/// `.environment(core)`. Cada feature accede a su store + al bus via
+/// `@Environment(AppCore.self)`.
+///
+/// **En Paso 1 del milestone** este objeto sólo instancia `EventBus` e
+/// `InterceptorRegistry`. Los stores de feature (BlockStore, MockStore, etc.)
+/// se agregan en milestones posteriores según cada feature migra.
+///
+/// **Scope**: reemplaza progresivamente a los 6 managers legacy de PryKit
+/// (`ProxyManager`, `RequestStoreWrapper`, `MockManager`, etc.). Durante la
+/// migración ambos conviven — cuando una feature migra, su manager PryKit se
+/// retira.
+@available(macOS 14, *)
+@Observable
+@MainActor
+public final class AppCore {
+    /// Bus de eventos. Features que observan (UI, Recorder, métricas) se
+    /// suscriben a tipos de eventos específicos.
+    public let bus: EventBus
+
+    /// Registro de interceptors. Features que mutan el flow se registran acá
+    /// al construirse el AppCore.
+    public let interceptors: InterceptorRegistry
+
+    public init() {
+        self.bus = EventBus()
+        self.interceptors = InterceptorRegistry()
+        // Los stores de feature se agregan en milestones siguientes.
+        // Ejemplo futuro (Paso 2):
+        //   self.blocks = BlockStore(bus: bus)
+        //   Task { await interceptors.register(BlockInterceptor(store: blocks)) }
+    }
+
+    /// Factory para `#Preview`. Genera un `AppCore` aislado sin efectos reales.
+    /// Cada feature puede proveer su propio seed via extension.
+    @available(macOS 14, *)
+    public static func preview() -> AppCore {
+        AppCore()
+    }
+}

--- a/Sources/PryApp/Core/EventBus.swift
+++ b/Sources/PryApp/Core/EventBus.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Broker pub/sub de eventos del ciclo de vida del proxy.
+///
+/// - Publicar: `await bus.publish(someEvent)` desde cualquier contexto.
+/// - Suscribir: `for await event in bus.subscribe(to: RequestCapturedEvent.self) { ... }`.
+///
+/// Cada subscriber recibe su propio stream. Cancelar el `Task` que lo consume
+/// desregistra automáticamente (vía `onTermination`).
+///
+/// Back-pressure: cada stream usa buffer con política **drop-oldest** y capacidad
+/// por default de 1000 eventos. Si un consumidor es lento, se pierden los eventos
+/// más viejos — el proxy nunca se bloquea por un subscriber lerdo.
+public actor EventBus {
+    /// Un subscriber activo: su filtro de tipo + la continuation que entrega eventos.
+    private struct Subscription {
+        let filter: (any PryEvent) -> (any PryEvent)?
+        let yield: (any PryEvent) -> Void
+    }
+
+    private var subscriptions: [UUID: Subscription] = [:]
+    private let bufferSize: Int
+
+    /// - Parameter bufferSize: cuántos eventos retiene cada stream antes de descartar
+    ///   los más viejos si el consumidor no los procesa. Default 1000.
+    public init(bufferSize: Int = 1000) {
+        self.bufferSize = bufferSize
+    }
+
+    /// Publica un evento a todos los subscribers interesados (filtrados por tipo).
+    public func publish<E: PryEvent>(_ event: E) {
+        for sub in subscriptions.values {
+            if let _ = sub.filter(event) {
+                sub.yield(event)
+            }
+        }
+    }
+
+    /// Suscribe a eventos de un tipo específico. Retorna un `AsyncStream` que
+    /// termina automáticamente cuando el `Task` consumidor se cancela.
+    ///
+    /// Uso típico:
+    /// ```swift
+    /// Task {
+    ///     for await event in bus.subscribe(to: RequestCapturedEvent.self) {
+    ///         // reaccionar al evento
+    ///     }
+    /// }
+    /// ```
+    public nonisolated func subscribe<E: PryEvent>(to _: E.Type = E.self) -> AsyncStream<E> {
+        AsyncStream<E>(bufferingPolicy: .bufferingNewest(bufferSize)) { continuation in
+            let id = UUID()
+            let subscription = Subscription(
+                filter: { event in event is E ? event : nil },
+                yield: { event in
+                    if let typed = event as? E {
+                        continuation.yield(typed)
+                    }
+                }
+            )
+            // Registrar la subscription dentro del actor.
+            Task { await self.addSubscription(id: id, subscription: subscription) }
+            // Auto-unregister cuando el stream termina (Task cancelado, deinit, etc.).
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.removeSubscription(id: id) }
+            }
+        }
+    }
+
+    private func addSubscription(id: UUID, subscription: Subscription) {
+        subscriptions[id] = subscription
+    }
+
+    private func removeSubscription(id: UUID) {
+        subscriptions.removeValue(forKey: id)
+    }
+
+    /// Cantidad de subscribers activos. Útil para debugging y tests.
+    public var subscriberCount: Int {
+        subscriptions.count
+    }
+}

--- a/Sources/PryApp/Core/Events.swift
+++ b/Sources/PryApp/Core/Events.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Marker protocol para todo evento publicable al `EventBus`.
+///
+/// Los eventos son value types `Sendable` con los datos mínimos para reaccionar.
+/// **No incluyen bodies** — si un subscriber los necesita, accede al store
+/// correspondiente por id.
+public protocol PryEvent: Sendable {}
+
+// MARK: - Ciclo de vida de request
+
+/// Emitido cuando el proxy captura una request nueva (antes de procesarla por la chain).
+public struct RequestCapturedEvent: PryEvent {
+    public let requestID: UUID
+    public let method: String
+    public let host: String
+    public let path: String
+    public let capturedAt: Date
+
+    public init(requestID: UUID, method: String, host: String, path: String, capturedAt: Date = Date()) {
+        self.requestID = requestID
+        self.method = method
+        self.host = host
+        self.path = path
+        self.capturedAt = capturedAt
+    }
+}
+
+/// Emitido cuando la response correspondiente llega (del servidor o de un short-circuit).
+public struct ResponseReceivedEvent: PryEvent {
+    public let requestID: UUID
+    public let status: Int
+    public let duration: TimeInterval
+    public let isMock: Bool
+
+    public init(requestID: UUID, status: Int, duration: TimeInterval, isMock: Bool) {
+        self.requestID = requestID
+        self.status = status
+        self.duration = duration
+        self.isMock = isMock
+    }
+}
+
+/// Emitido cuando un interceptor retorna `.pause` — la request quedó en espera de
+/// resolución externa (típicamente de la UI de Breakpoints).
+public struct RequestPausedEvent: PryEvent {
+    public let requestID: UUID
+    public let pausedAt: Date
+
+    public init(requestID: UUID, pausedAt: Date = Date()) {
+        self.requestID = requestID
+        self.pausedAt = pausedAt
+    }
+}
+
+// MARK: - Lifecycle global
+
+/// Emitido cuando el usuario limpia el historial de tráfico (botón "Clear").
+/// Los subscribers (UI, recorder, etc.) deben reaccionar vaciando sus caches.
+public struct TrafficClearedEvent: PryEvent {
+    public let clearedAt: Date
+    public init(clearedAt: Date = Date()) { self.clearedAt = clearedAt }
+}
+
+// MARK: - Tunnels (CONNECT / TLS)
+
+/// Un tunnel HTTPS CONNECT se estableció hacia `host:port`. El tráfico encriptado
+/// dentro del tunnel produce sus propios `RequestCapturedEvent` si hay intercepción.
+public struct TunnelOpenedEvent: PryEvent {
+    public let tunnelID: UUID
+    public let host: String
+    public let port: Int
+    public let openedAt: Date
+
+    public init(tunnelID: UUID, host: String, port: Int, openedAt: Date = Date()) {
+        self.tunnelID = tunnelID
+        self.host = host
+        self.port = port
+        self.openedAt = openedAt
+    }
+}
+
+/// Un tunnel se cerró (por fin de sesión, timeout, o error).
+public struct TunnelClosedEvent: PryEvent {
+    public let tunnelID: UUID
+    public let closedAt: Date
+    public init(tunnelID: UUID, closedAt: Date = Date()) {
+        self.tunnelID = tunnelID
+        self.closedAt = closedAt
+    }
+}

--- a/Sources/PryApp/Core/Interceptor.swift
+++ b/Sources/PryApp/Core/Interceptor.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Contrato único para features que **mutan** el flow del proxy.
+///
+/// Implementaciones típicas: `BlockInterceptor` (gate), `MockInterceptor` (resolve),
+/// `HeaderRewriteInterceptor` (transform), `ThrottleInterceptor` (network).
+///
+/// Si una feature sólo **observa** sin mutar (UI, Recorder, métricas), NO implementa
+/// este protocolo — suscribe al `EventBus` en su lugar.
+///
+/// Los interceptors se ejecutan en orden de `phase` (ver `Phase`). Dentro de una
+/// misma phase el orden es de registro (FIFO).
+public protocol Interceptor: Sendable {
+    /// Fase en la que corre este interceptor. Define el orden global del pipeline.
+    var phase: Phase { get }
+
+    /// Procesa una request. Retorna un `InterceptResult` que indica cómo continúa
+    /// el pipeline.
+    ///
+    /// - Parameter ctx: la request actual (potencialmente mutada por interceptors anteriores).
+    /// - Returns: pass / transform / shortCircuit / pause.
+    func intercept(_ ctx: RequestContext) async -> InterceptResult
+}
+
+/// Ordinalidad del pipeline. Un interceptor sólo corre cuando llega su phase.
+///
+/// Racional del orden:
+/// 1. `.gate` — denegaciones tempranas (BlockList, allowlists). Evita trabajo innecesario.
+/// 2. `.resolve` — respuestas sin ir a la red (Mock, MapLocal). Short-circuits frecuentes.
+/// 3. `.transform` — modifica la request saliente (HeaderRewrite, Rules).
+/// 4. `.network` — ajusta destino o timing antes del forward (Throttle, DNS, MapRemote).
+public enum Phase: Int, Comparable, Sendable, CaseIterable {
+    case gate = 0
+    case resolve = 1
+    case transform = 2
+    case network = 3
+
+    public static func < (lhs: Phase, rhs: Phase) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// Resultado de `intercept`. Define cómo continúa el pipeline.
+public enum InterceptResult: Sendable {
+    /// Pasar al siguiente interceptor sin cambios.
+    case pass
+
+    /// Pasar al siguiente interceptor con una versión mutada del contexto.
+    /// Usado típicamente en phase `.transform` (ej. HeaderRewrite).
+    case transform(RequestContext)
+
+    /// Cortar el pipeline y responder directamente sin ir al servidor real.
+    /// Usado por Mock, BlockList, MapLocal. El pipeline NO ejecuta interceptors posteriores.
+    case shortCircuit(Response)
+
+    /// Pausar la request hasta que una acción externa (típicamente UI) resuelva.
+    /// La closure debe eventualmente retornar otro `InterceptResult` que indica
+    /// cómo continuar (pass con ctx mutado, shortCircuit, etc.). Usado por Breakpoints.
+    case pause(resolution: @Sendable () async -> InterceptResult)
+}

--- a/Sources/PryApp/Core/InterceptorRegistry.swift
+++ b/Sources/PryApp/Core/InterceptorRegistry.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Registro thread-safe de interceptors activos.
+///
+/// - Features **registran** su interceptor al construirse (típicamente desde `AppCore.init`).
+/// - El pipeline de proxy **pide la chain ordenada** con `chain()` antes de procesar
+///   cada request.
+/// - Un `register` retorna un token opaco (`UUID`) que permite `unregister` más
+///   adelante. Esto habilita enable/disable en runtime sin reiniciar el proxy.
+public actor InterceptorRegistry {
+    private var interceptors: [UUID: any Interceptor] = [:]
+
+    public init() {}
+
+    /// Registra un interceptor y retorna un token para desregistrarlo después.
+    @discardableResult
+    public func register(_ interceptor: any Interceptor) -> UUID {
+        let id = UUID()
+        interceptors[id] = interceptor
+        return id
+    }
+
+    /// Quita un interceptor previamente registrado. No-op si el token no existe.
+    public func unregister(_ id: UUID) {
+        interceptors.removeValue(forKey: id)
+    }
+
+    /// Retorna todos los interceptors actuales ordenados por `phase`.
+    /// Dentro de una misma phase no se garantiza orden estable.
+    public func chain() -> [any Interceptor] {
+        interceptors.values.sorted { $0.phase < $1.phase }
+    }
+
+    /// Cantidad de interceptors registrados. Útil para debugging y tests.
+    public var count: Int {
+        interceptors.count
+    }
+}

--- a/Sources/PryApp/Core/RequestContext.swift
+++ b/Sources/PryApp/Core/RequestContext.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Representa una request HTTP que atraviesa el pipeline de interceptors de PryApp.
+///
+/// Value type intencionalmente NIO-agnóstico: los interceptors operan sobre este
+/// contexto sin tener que conocer `HTTPRequestHead`, `ByteBuffer`, o cualquier otro
+/// tipo de NIO. La traducción desde/hacia NIO vive en la capa de integración
+/// (milestone 2, fuera del scope de Paso 1).
+///
+/// Un interceptor puede retornar `.transform(newCtx)` devolviendo una copia mutada
+/// de este struct — como todos los campos son value types, mutations son seguras y
+/// no afectan al caller.
+public struct RequestContext: Sendable, Identifiable {
+    /// Identificador único de la request durante su ciclo de vida en el pipeline.
+    /// Se mantiene estable entre el request y la response.
+    public let id: UUID
+
+    /// Método HTTP en mayúsculas (`GET`, `POST`, `PUT`, etc.).
+    public var method: String
+
+    /// Host de destino sin scheme ni puerto (`api.example.com`).
+    public var host: String
+
+    /// Path + query string (`/v1/users?id=42`). No incluye host.
+    public var path: String
+
+    /// Puerto de destino. Default 443 para HTTPS, 80 para HTTP.
+    public var port: Int
+
+    /// Headers como diccionario case-preserving. Las keys se comparan case-insensitive
+    /// en los interceptors que hagan matching semántico.
+    public var headers: [String: String]
+
+    /// Referencia opaca al body. `nil` para requests sin body (GET típico) o cuando
+    /// el body aún no fue leído del stream. Ver `BodyRef` para el contrato de acceso.
+    public var bodyRef: BodyRef?
+
+    /// Timestamp de captura (cuando el proxy recibió la request).
+    public let capturedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        method: String,
+        host: String,
+        path: String,
+        port: Int = 443,
+        headers: [String: String] = [:],
+        bodyRef: BodyRef? = nil,
+        capturedAt: Date = Date()
+    ) {
+        self.id = id
+        self.method = method
+        self.host = host
+        self.path = path
+        self.port = port
+        self.headers = headers
+        self.bodyRef = bodyRef
+        self.capturedAt = capturedAt
+    }
+}
+
+/// Referencia a un body HTTP. El body real puede ser grande (MB), por lo que se
+/// entrega por referencia — los consumidores piden el contenido on-demand con
+/// `read()`. Evita copiar bodies cuando un interceptor sólo necesita headers.
+public struct BodyRef: Sendable {
+    /// Tamaño en bytes (conocido sin leer el body completo cuando es posible).
+    public let contentLength: Int?
+
+    /// Función asíncrona que entrega el body completo. Puede fallar si el body
+    /// ya fue consumido o liberado (ej. request muy vieja ya evictada del store).
+    public let read: @Sendable () async throws -> Data
+
+    public init(contentLength: Int?, read: @escaping @Sendable () async throws -> Data) {
+        self.contentLength = contentLength
+        self.read = read
+    }
+}

--- a/Sources/PryApp/Core/Response.swift
+++ b/Sources/PryApp/Core/Response.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Representa una respuesta HTTP producida por un interceptor o recibida desde el
+/// servidor de destino. Value type NIO-agnóstico, simétrico a `RequestContext`.
+public struct Response: Sendable {
+    /// Status code HTTP (200, 403, 404, 500...).
+    public var status: Int
+
+    /// Headers de respuesta. Keys case-preserving.
+    public var headers: [String: String]
+
+    /// Body como `Data`. Para responses mockeadas suele ser pequeño; para responses
+    /// forwarded desde servidor real puede ser grande — ver `BodyRef` en futuras
+    /// iteraciones si aparece presión de memoria.
+    public var body: Data?
+
+    public init(status: Int, headers: [String: String] = [:], body: Data? = nil) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// MARK: - Factories comunes
+
+public extension Response {
+    /// 403 Forbidden con body JSON de explicación. Usado típicamente por interceptors
+    /// tipo BlockList o allowlists en phase `.gate`.
+    static func forbidden(reason: String = "Blocked by Pry") -> Response {
+        Response(
+            status: 403,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"error":"\#(reason)"}"#.utf8)
+        )
+    }
+
+    /// 200 OK con body JSON. Usado por interceptors de mocking.
+    static func ok(json: String) -> Response {
+        Response(
+            status: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(json.utf8)
+        )
+    }
+
+    /// 200 OK con body arbitrario.
+    static func ok(body: Data, contentType: String = "application/octet-stream") -> Response {
+        Response(
+            status: 200,
+            headers: ["Content-Type": contentType],
+            body: body
+        )
+    }
+
+    /// 404 Not Found vacío — útil para MapLocal cuando el archivo no existe.
+    static func notFound() -> Response {
+        Response(status: 404)
+    }
+}


### PR DESCRIPTION
## Summary

Paso 1 del Milestone 1 de la migración a la arquitectura del [ADR-006](./docs/ADR-006-new-architecture-desktop-app.md).

Agrega el scaffolding de 7 archivos en \`Sources/PryApp/Core/\` — los protocolos y tipos base de la nueva arquitectura. **Código nuevo inerte**: nada se conecta al flow actual todavía, la app funciona exactamente igual que antes.

## Archivos nuevos

| Archivo | Rol | LOC |
|---|---|---|
| \`Interceptor.swift\` | protocolo + \`Phase\` (gate/resolve/transform/network) + \`InterceptResult\` (pass/transform/shortCircuit/pause) | 60 |
| \`RequestContext.swift\` | value type \`Sendable\` NIO-agnóstico + \`BodyRef\` para acceso lazy | 77 |
| \`Response.swift\` | value type + factories (\`.forbidden\`, \`.ok(json:)\`, \`.notFound\`) | 59 |
| \`InterceptorRegistry.swift\` | \`actor\` thread-safe con register/unregister/chain | 38 |
| \`EventBus.swift\` | \`actor\` pub/sub con \`AsyncStream\` + drop-oldest + auto-unsubscribe | 82 |
| \`Events.swift\` | \`PryEvent\` protocol + 6 events (RequestCaptured, ResponseReceived, RequestPaused, TrafficCleared, TunnelOpened, TunnelClosed) | 91 |
| \`AppCore.swift\` | composition root \`@Observable @MainActor\` + \`preview()\` factory | 45 |
| **Total** | | **452** |

100% documentado con \`///\`.

## Nada que se modifica

- \`PryApp.swift\`, \`MainWindow.swift\`, \`ContentView.swift\` — intactos
- \`HTTPInterceptor.swift\`, \`ConnectHandler.swift\` — intactos
- \`BlockList.swift\` y demás stores legacy — intactos
- \`Package.swift\` — intacto (los files caen dentro del target PryApp existente)

## Verificación

\`\`\`
swift build  # ✓ compila sin warnings nuevos vs main
swift test   # ✓ todos los tests existentes siguen pasando
\`\`\`

## Próximo paso

Paso 2: primera feature migrada (\`Blocking\`) usando \`/new-feature\`. Incluye:
- \`BlockStore\` + \`BlockInterceptor\` + \`BlocksView\` con tests TDD-first
- Inyección de \`AppCore\` al root (\`PryApp.swift\`)
- Template validado para replicar en el resto de features

## No incluye

- Ninguna modificación del pipeline real (\`HTTPInterceptor\`, \`ConnectHandler\`) — eso es Milestone 2.
- Ningún cambio en CLI (\`Sources/Pry/main.swift\`) — CLI no se toca nunca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)