### PR TITLE
fix: watchdog subprocess para prevenir proxy huérfano tras crash

### DIFF
--- a/Sources/Pry/main.swift
+++ b/Sources/Pry/main.swift
@@ -109,6 +109,24 @@ guard let command = args.first else {
     exit(0)
 }
 
+// Watchdog subprocess mode: `pry --watchdog <parent_pid>`
+// Bloquea en un loop observando al padre (PryApp). Si el padre muere de golpe
+// (SIGKILL, force-quit, crash), el watchdog restaura el system proxy para que
+// el Mac no pierda la red. Si hay un sentinel file, sale silenciosamente
+// (shutdown limpio en curso). Solo Foundation + Darwin, sin NIO.
+if command == "--watchdog" {
+    guard args.count >= 2, let parentPID = pid_t(args[1]) else {
+        fputs("Usage: pry --watchdog <parent_pid>\n", stderr)
+        exit(2)
+    }
+    fputs("[pry-watchdog] starting, watching pid \(parentPID)\n", stderr)
+    // Ignorar SIGPIPE por si stderr se cierra cuando el padre muere.
+    signal(SIGPIPE, SIG_IGN)
+    let result = Watchdog.run(parentPID: parentPID)
+    fputs("[pry-watchdog] exiting: \(result)\n", stderr)
+    exit(0)
+}
+
 // Check for orphaned proxy config on every CLI invocation
 ProxyGuard.cleanupIfNeeded()
 

--- a/Sources/PryKit/ProxyManager.swift
+++ b/Sources/PryKit/ProxyManager.swift
@@ -12,12 +12,17 @@ public final class ProxyManager {
     public var requestCount: Int = 0
     public var domains: [String] = []
     public var systemProxyEnabled = false
+    /// True cuando el watchdog subprocess está corriendo y monitoreando a PryApp.
+    /// Si es false después de un `start()`, probablemente no encontramos el binario `pry`
+    /// — el proxy funciona igual, pero sin protección contra force-quit del Mac.
+    public var watchdogRunning: Bool = false
     /// Mensaje efímero a mostrar como banner en la GUI (toasts de acción).
     /// Se setea tras operaciones que requieren que el usuario entienda el efecto
     /// (ej. agregar dominio al watchlist con proxy corriendo). La UI limpia después de mostrarlo.
     public var statusBanner: String?
 
     private let serverBox = ServerBox()
+    private let watchdogBox = WatchdogBox()
 
     public init(port: Int = Config.port()) {
         self.port = port
@@ -33,9 +38,15 @@ public final class ProxyManager {
         reloadDomains()
         // Auto-enable system proxy so traffic flows through Pry
         enableSystemProxy()
+        // Spawn watchdog: si PryApp es force-quit (SIGKILL), el watchdog restaura
+        // el system proxy para que el Mac no se quede sin red.
+        spawnWatchdog()
     }
 
     public func stop() {
+        // Write sentinel + terminate watchdog BEFORE disabling proxy, para evitar
+        // que el watchdog gane la carrera y "limpie" algo que estamos limpiando nosotros.
+        shutdownWatchdog()
         // Restore system proxy before shutting down
         disableSystemProxy()
         serverBox.shutdownIfNeeded()
@@ -95,8 +106,71 @@ public final class ProxyManager {
         reloadDomains()
     }
 
+    // MARK: - Watchdog
+
+    /// Spawnea `pry --watchdog <getpid()>` como proceso detached. Si PryApp es
+    /// force-quit (kill -9) o crashea, el watchdog detecta al padre muerto y
+    /// restaura el system proxy — sin él, el Mac quedaría sin red hasta la
+    /// próxima vez que alguien ejecute `pry`.
+    private func spawnWatchdog() {
+        if watchdogBox.isRunning { return }
+        guard let binary = resolvePryBinary() else {
+            fputs("[ProxyManager] Warning: no se encontró el binario `pry`, watchdog deshabilitado. Si PryApp cae abruptamente, ejecutar `pry start` o `pry stop` restaurará la red.\n", stderr)
+            watchdogRunning = false
+            return
+        }
+        let ppid = ProcessInfo.processInfo.processIdentifier
+        // Limpiar cualquier sentinel stale de un ciclo anterior del mismo PID.
+        try? FileManager.default.removeItem(atPath: Watchdog.sentinelPath(for: ppid))
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = ["--watchdog", "\(ppid)"]
+        // Descartar stdout/stderr del watchdog para no contaminar la GUI.
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            watchdogBox.set(process: process, parentPID: ppid)
+            watchdogRunning = true
+        } catch {
+            fputs("[ProxyManager] Failed to spawn watchdog: \(error)\n", stderr)
+            watchdogRunning = false
+        }
+    }
+
+    /// Shutdown ordenado del watchdog: escribe sentinel, llama `.terminate()`,
+    /// espera brevemente, borra sentinel.
+    private func shutdownWatchdog() {
+        watchdogBox.shutdownGracefully(timeout: 1.0)
+        watchdogRunning = false
+    }
+
+    /// Intenta resolver el path del binario `pry`:
+    /// 1. Sibling del ejecutable actual (dentro de `PryApp.app/Contents/MacOS/pry`)
+    /// 2. `/usr/local/bin/pry` (Homebrew Intel / make install)
+    /// 3. `/opt/homebrew/bin/pry` (Homebrew Apple Silicon)
+    /// Devuelve nil si ningún candidato es ejecutable — el caller loguea warning.
+    private func resolvePryBinary() -> String? {
+        let fm = FileManager.default
+        var candidates: [String] = []
+        if let exec = Bundle.main.executablePath {
+            let sibling = (exec as NSString).deletingLastPathComponent + "/pry"
+            candidates.append(sibling)
+        }
+        candidates.append("/usr/local/bin/pry")
+        candidates.append("/opt/homebrew/bin/pry")
+        for c in candidates where fm.isExecutableFile(atPath: c) {
+            return c
+        }
+        return nil
+    }
+
     deinit {
-        // Ensure system proxy is restored even on unexpected termination
+        // Belt-and-suspenders: si llegamos acá sin haber llamado stop(),
+        // apagar watchdog y system proxy. Usamos el box (Sendable) porque
+        // deinit no puede invocar métodos MainActor-isolated.
+        watchdogBox.shutdownGracefully(timeout: 0.5)
         SystemProxy.disable()
         ProxyState.clear()
         serverBox.shutdownIfNeeded()
@@ -118,6 +192,48 @@ private final class ServerBox: @unchecked Sendable {
         lock.withLock {
             _server?.shutdown()
             _server = nil
+        }
+    }
+}
+
+/// Thread-safe box para el Process del watchdog, permite acceso desde `deinit`
+/// sin violar aislamiento de MainActor.
+private final class WatchdogBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _process: Process?
+    private var _parentPID: pid_t?
+
+    var isRunning: Bool {
+        lock.withLock { _process?.isRunning ?? false }
+    }
+
+    func set(process: Process, parentPID: pid_t) {
+        lock.withLock {
+            _process = process
+            _parentPID = parentPID
+        }
+    }
+
+    /// Shutdown limpio: escribe sentinel, termina el proceso, espera hasta `timeout`,
+    /// borra sentinel, limpia referencias. Idempotente.
+    func shutdownGracefully(timeout: TimeInterval) {
+        // Capturar referencias bajo lock, trabajar fuera del lock para no bloquear.
+        let (process, ppid): (Process?, pid_t?) = lock.withLock { (_process, _parentPID) }
+        guard let process = process, let ppid = ppid else { return }
+        let sentinel = Watchdog.sentinelPath(for: ppid)
+        StoragePaths.ensureRoot()
+        FileManager.default.createFile(atPath: sentinel, contents: Data())
+        if process.isRunning {
+            process.terminate()
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        try? FileManager.default.removeItem(atPath: sentinel)
+        lock.withLock {
+            _process = nil
+            _parentPID = nil
         }
     }
 }

--- a/Sources/PryLib/Watchdog.swift
+++ b/Sources/PryLib/Watchdog.swift
@@ -1,0 +1,115 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// Watchdog — proceso hijo que monitorea al padre (PryApp) y limpia el
+/// system proxy si el padre muere de forma abrupta (SIGKILL, force-quit, crash).
+///
+/// Sin el watchdog: si PryApp es force-quit mientras el system proxy está en
+/// `localhost:8080`, el Mac pierde toda la red hasta que alguien relance Pry
+/// (que llamaría `ProxyGuard.cleanupIfNeeded()` en el launch).
+///
+/// Con el watchdog: un `pry --watchdog <parent_pid>` spawned como detached
+/// child observa al padre con `kill(pid, 0)` cada 3s. Si el padre muere →
+/// disable el system proxy. Si el padre hace Stop ordenado, crea un sentinel
+/// file para que el watchdog salga sin tocar el proxy state.
+public enum Watchdog {
+
+    /// Intervalo de polling por default (3 segundos, como describe el issue).
+    public static let defaultPollInterval: TimeInterval = 3.0
+
+    /// Path del sentinel file para un parent PID dado.
+    /// Si existe cuando el watchdog verifica, significa "shutdown limpio en curso,
+    /// no limpies nada".
+    public static func sentinelPath(for parentPID: pid_t) -> String {
+        "\(StoragePaths.root)/watchdog-shutdown-\(parentPID)"
+    }
+
+    /// Default implementation de `processAlive`: usa `kill(pid, 0)` para
+    /// comprobar si un proceso existe. Devuelve false si la llamada falla
+    /// con ESRCH (no such process).
+    public static let defaultProcessAlive: @Sendable (pid_t) -> Bool = { pid in
+        // kill con signal 0 no envía nada, solo chequea si el proceso existe
+        // y si tenemos permiso para enviarle señales. Retorna 0 si existe.
+        if kill(pid, 0) == 0 { return true }
+        // errno == ESRCH significa que el proceso no existe
+        return errno != ESRCH
+    }
+
+    /// Default implementation de `sentinelExists`: chequea el filesystem.
+    public static let defaultSentinelExists: @Sendable (String) -> Bool = { path in
+        FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Resultado del run del watchdog.
+    public enum RunResult: Equatable {
+        /// El padre murió y se ejecutó el cleanup (disable system proxy).
+        case cleanupExecuted
+        /// El sentinel file estaba presente (shutdown limpio), salida silenciosa.
+        case silentExit
+        /// Se alcanzó el tope de iteraciones (solo usado en tests).
+        case maxIterationsReached
+    }
+
+    /// Cleanup default: disable system proxy + clear proxy state + remove pid file.
+    /// Esto es lo mismo que haría ProxyGuard ante un orphan, pero sin chequeos de
+    /// orphan porque acá ya sabemos que el padre murió.
+    public static let defaultCleanup: @Sendable () -> Void = {
+        if let state = ProxyState.load() {
+            SystemProxy.disable(service: state.networkService)
+        } else {
+            SystemProxy.disable()
+        }
+        ProxyState.clear()
+        try? FileManager.default.removeItem(atPath: Config.pidFile)
+    }
+
+    /// Ejecuta el loop del watchdog. Diseñado para ser testeable mediante
+    /// inyección de dependencias (processAlive, sentinelExists, sleep, onCleanup).
+    ///
+    /// - Parameters:
+    ///   - parentPID: PID del proceso padre a monitorear.
+    ///   - pollInterval: Intervalo entre polls (default 3s, override en tests).
+    ///   - processAlive: Predicado para chequear si un PID está vivo.
+    ///   - sentinelExists: Predicado para chequear si el sentinel file existe.
+    ///   - sleep: Función de sleep (default `Thread.sleep`), override en tests.
+    ///   - onCleanup: Acción a ejecutar si el padre muere sin sentinel.
+    ///                Default: disable system proxy + clear state + remove pid file.
+    ///   - maxIterations: Tope opcional de iteraciones (para tests). nil = sin límite.
+    /// - Returns: El resultado del run (cleanup ejecutado, silent exit, o tope de iteraciones).
+    @discardableResult
+    public static func run(
+        parentPID: pid_t,
+        pollInterval: TimeInterval = Watchdog.defaultPollInterval,
+        processAlive: @Sendable (pid_t) -> Bool = Watchdog.defaultProcessAlive,
+        sentinelExists: @Sendable (String) -> Bool = Watchdog.defaultSentinelExists,
+        sleep: @Sendable (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
+        onCleanup: @Sendable () -> Void = Watchdog.defaultCleanup,
+        maxIterations: Int? = nil
+    ) -> RunResult {
+        let sentinel = sentinelPath(for: parentPID)
+        var iterations = 0
+        while true {
+            // 1. Sentinel file? El padre anunció un shutdown limpio → salir sin tocar nada.
+            if sentinelExists(sentinel) {
+                fputs("[pry-watchdog] sentinel detected for pid \(parentPID), exiting silently\n", stderr)
+                return .silentExit
+            }
+            // 2. Padre muerto? → cleanup y salir.
+            if !processAlive(parentPID) {
+                fputs("[pry-watchdog] parent pid \(parentPID) is gone, cleaning up system proxy\n", stderr)
+                onCleanup()
+                return .cleanupExecuted
+            }
+            // 3. Padre vivo, sin sentinel → seguir mirando.
+            iterations += 1
+            if let max = maxIterations, iterations >= max {
+                return .maxIterationsReached
+            }
+            sleep(pollInterval)
+        }
+    }
+}

--- a/Tests/PryLibTests/WatchdogTests.swift
+++ b/Tests/PryLibTests/WatchdogTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import PryLib
+
+final class WatchdogTests: XCTestCase {
+
+    // MARK: - Logic via dependency injection
+    //
+    // Los tests evitan spawnear procesos reales o dormir por segundos.
+    // Se inyecta `processAlive`, `sentinelExists` y `sleep` para controlar
+    // el loop de forma determinística.
+
+    func testExitsWhenProcessDies_runsCleanup() {
+        // El proceso muere en la iteración 2. El cleanup debe ejecutarse exactamente una vez.
+        var aliveCallCount = 0
+        let aliveStub: @Sendable (pid_t) -> Bool = { _ in
+            aliveCallCount += 1
+            return aliveCallCount < 2   // iteración 1: alive, iteración 2: dead
+        }
+
+        var cleanupCalls = 0
+        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+
+        let result = Watchdog.run(
+            parentPID: 99999,
+            pollInterval: 0.01,
+            processAlive: aliveStub,
+            sentinelExists: { _ in false },
+            sleep: { _ in },
+            onCleanup: cleanup
+        )
+
+        XCTAssertEqual(result, .cleanupExecuted)
+        XCTAssertEqual(cleanupCalls, 1, "cleanup debería ejecutarse exactamente una vez")
+    }
+
+    func testExitsSilentlyWhenSentinelPresent_doesNotCleanup() {
+        // Sentinel presente desde el arranque → salida silenciosa, sin tocar proxy.
+        var cleanupCalls = 0
+        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+
+        let result = Watchdog.run(
+            parentPID: 12345,
+            pollInterval: 0.01,
+            processAlive: { _ in true }, // aunque el padre siga vivo
+            sentinelExists: { _ in true },
+            sleep: { _ in XCTFail("no debería dormir — sale en la primera iteración") },
+            onCleanup: cleanup
+        )
+
+        XCTAssertEqual(result, .silentExit)
+        XCTAssertEqual(cleanupCalls, 0, "cleanup NO debería ejecutarse cuando hay sentinel")
+    }
+
+    func testSentinelWinsEvenIfProcessAlsoDead() {
+        // Si aparecen ambas condiciones a la vez (sentinel + padre muerto),
+        // el sentinel manda → no hacemos cleanup. Esto es el ordering correcto
+        // para evitar que `stop()` de PryApp (que escribe sentinel y luego mata
+        // system proxy él mismo) se pise con el watchdog.
+        var cleanupCalls = 0
+        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+
+        let result = Watchdog.run(
+            parentPID: 12345,
+            pollInterval: 0.01,
+            processAlive: { _ in false },
+            sentinelExists: { _ in true },
+            sleep: { _ in },
+            onCleanup: cleanup
+        )
+
+        XCTAssertEqual(result, .silentExit)
+        XCTAssertEqual(cleanupCalls, 0)
+    }
+
+    func testContinuesPollingWhileProcessAlive() {
+        // Padre siempre vivo, sin sentinel → debería hacer exactamente `maxIterations` polls
+        // y cortar con `.maxIterationsReached` sin llamar cleanup.
+        var aliveCalls = 0
+        var sleepCalls = 0
+        var cleanupCalls = 0
+
+        let result = Watchdog.run(
+            parentPID: 12345,
+            pollInterval: 0.01,
+            processAlive: { _ in
+                aliveCalls += 1
+                return true
+            },
+            sentinelExists: { _ in false },
+            sleep: { _ in sleepCalls += 1 },
+            onCleanup: { cleanupCalls += 1 },
+            maxIterations: 5
+        )
+
+        XCTAssertEqual(result, .maxIterationsReached)
+        XCTAssertEqual(aliveCalls, 5, "debería hacer 5 polls exactos")
+        // Sleep corre entre polls; tras el 5º poll cortamos antes de dormir.
+        XCTAssertEqual(sleepCalls, 4, "debería dormir 4 veces entre 5 polls")
+        XCTAssertEqual(cleanupCalls, 0, "cleanup NO debería ejecutarse mientras el padre vive")
+    }
+
+    func testSentinelPathUsesParentPID() {
+        // El path del sentinel debe ser estable y contener el parent PID para
+        // evitar colisiones si hay múltiples PryApp running (caso raro pero
+        // posible durante dev/tests).
+        let path1 = Watchdog.sentinelPath(for: 1234)
+        let path2 = Watchdog.sentinelPath(for: 5678)
+        XCTAssertNotEqual(path1, path2)
+        XCTAssertTrue(path1.contains("1234"))
+        XCTAssertTrue(path2.contains("5678"))
+        XCTAssertTrue(path1.contains("watchdog-shutdown"))
+    }
+
+    // MARK: - Real process checks
+
+    func testDefaultProcessAliveReturnsTrueForCurrentPID() {
+        // El proceso del test suite está vivo, obviamente.
+        let myPid = ProcessInfo.processInfo.processIdentifier
+        XCTAssertTrue(Watchdog.defaultProcessAlive(myPid))
+    }
+
+    func testDefaultProcessAliveReturnsFalseForImpossiblePID() {
+        // PID 999999 casi seguro no existe (max PID en macOS es típicamente ~99999).
+        XCTAssertFalse(Watchdog.defaultProcessAlive(999999))
+    }
+
+    // MARK: - Sentinel file checks
+
+    func testDefaultSentinelExistsWorksWithRealFS() {
+        let tempPath = NSTemporaryDirectory() + "watchdog-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempPath) }
+
+        XCTAssertFalse(Watchdog.defaultSentinelExists(tempPath))
+        FileManager.default.createFile(atPath: tempPath, contents: Data())
+        XCTAssertTrue(Watchdog.defaultSentinelExists(tempPath))
+    }
+}

--- a/Tests/PryLibTests/WatchdogTests.swift
+++ b/Tests/PryLibTests/WatchdogTests.swift
@@ -1,6 +1,19 @@
 import XCTest
 @testable import PryLib
 
+/// Helper thread-safe counter — evita problemas de strict concurrency al
+/// capturar contadores en closures `@Sendable`.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int {
+        lock.withLock { _value }
+    }
+    func increment() {
+        lock.withLock { _value += 1 }
+    }
+}
+
 final class WatchdogTests: XCTestCase {
 
     // MARK: - Logic via dependency injection
@@ -11,14 +24,14 @@ final class WatchdogTests: XCTestCase {
 
     func testExitsWhenProcessDies_runsCleanup() {
         // El proceso muere en la iteración 2. El cleanup debe ejecutarse exactamente una vez.
-        var aliveCallCount = 0
+        let aliveCallCount = Counter()
         let aliveStub: @Sendable (pid_t) -> Bool = { _ in
-            aliveCallCount += 1
-            return aliveCallCount < 2   // iteración 1: alive, iteración 2: dead
+            aliveCallCount.increment()
+            return aliveCallCount.value < 2   // iteración 1: alive, iteración 2: dead
         }
 
-        var cleanupCalls = 0
-        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+        let cleanupCalls = Counter()
+        let cleanup: @Sendable () -> Void = { cleanupCalls.increment() }
 
         let result = Watchdog.run(
             parentPID: 99999,
@@ -30,13 +43,13 @@ final class WatchdogTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .cleanupExecuted)
-        XCTAssertEqual(cleanupCalls, 1, "cleanup debería ejecutarse exactamente una vez")
+        XCTAssertEqual(cleanupCalls.value, 1, "cleanup debería ejecutarse exactamente una vez")
     }
 
     func testExitsSilentlyWhenSentinelPresent_doesNotCleanup() {
         // Sentinel presente desde el arranque → salida silenciosa, sin tocar proxy.
-        var cleanupCalls = 0
-        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+        let cleanupCalls = Counter()
+        let cleanup: @Sendable () -> Void = { cleanupCalls.increment() }
 
         let result = Watchdog.run(
             parentPID: 12345,
@@ -48,7 +61,7 @@ final class WatchdogTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .silentExit)
-        XCTAssertEqual(cleanupCalls, 0, "cleanup NO debería ejecutarse cuando hay sentinel")
+        XCTAssertEqual(cleanupCalls.value, 0, "cleanup NO debería ejecutarse cuando hay sentinel")
     }
 
     func testSentinelWinsEvenIfProcessAlsoDead() {
@@ -56,8 +69,8 @@ final class WatchdogTests: XCTestCase {
         // el sentinel manda → no hacemos cleanup. Esto es el ordering correcto
         // para evitar que `stop()` de PryApp (que escribe sentinel y luego mata
         // system proxy él mismo) se pise con el watchdog.
-        var cleanupCalls = 0
-        let cleanup: @Sendable () -> Void = { cleanupCalls += 1 }
+        let cleanupCalls = Counter()
+        let cleanup: @Sendable () -> Void = { cleanupCalls.increment() }
 
         let result = Watchdog.run(
             parentPID: 12345,
@@ -69,34 +82,34 @@ final class WatchdogTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .silentExit)
-        XCTAssertEqual(cleanupCalls, 0)
+        XCTAssertEqual(cleanupCalls.value, 0)
     }
 
     func testContinuesPollingWhileProcessAlive() {
         // Padre siempre vivo, sin sentinel → debería hacer exactamente `maxIterations` polls
         // y cortar con `.maxIterationsReached` sin llamar cleanup.
-        var aliveCalls = 0
-        var sleepCalls = 0
-        var cleanupCalls = 0
+        let aliveCalls = Counter()
+        let sleepCalls = Counter()
+        let cleanupCalls = Counter()
 
         let result = Watchdog.run(
             parentPID: 12345,
             pollInterval: 0.01,
             processAlive: { _ in
-                aliveCalls += 1
+                aliveCalls.increment()
                 return true
             },
             sentinelExists: { _ in false },
-            sleep: { _ in sleepCalls += 1 },
-            onCleanup: { cleanupCalls += 1 },
+            sleep: { _ in sleepCalls.increment() },
+            onCleanup: { cleanupCalls.increment() },
             maxIterations: 5
         )
 
         XCTAssertEqual(result, .maxIterationsReached)
-        XCTAssertEqual(aliveCalls, 5, "debería hacer 5 polls exactos")
+        XCTAssertEqual(aliveCalls.value, 5, "debería hacer 5 polls exactos")
         // Sleep corre entre polls; tras el 5º poll cortamos antes de dormir.
-        XCTAssertEqual(sleepCalls, 4, "debería dormir 4 veces entre 5 polls")
-        XCTAssertEqual(cleanupCalls, 0, "cleanup NO debería ejecutarse mientras el padre vive")
+        XCTAssertEqual(sleepCalls.value, 4, "debería dormir 4 veces entre 5 polls")
+        XCTAssertEqual(cleanupCalls.value, 0, "cleanup NO debería ejecutarse mientras el padre vive")
     }
 
     func testSentinelPathUsesParentPID() {


### PR DESCRIPTION
## Summary

Cierra #84. Cuando PryApp cae abruptamente (force-quit, `kill -9`, crash), el system proxy queda apuntando a un puerto muerto (`localhost:8080`) y el Mac pierde toda la red hasta que alguien relance `pry`. Los handlers existentes (SIGTERM/INT/HUP, atexit, `ProxyGuard.cleanupIfNeeded()` en launch) no capturan SIGKILL.

La solución es un watchdog subprocess: PryApp spawnea `pry --watchdog <getpid()>` como proceso hijo detached. El watchdog hace poll `kill(parentPID, 0)` cada 3s. Si el padre desaparece, deshabilita el system proxy y limpia estado. Un sentinel file en `~/.pry/watchdog-shutdown-<pid>` permite que el Stop ordenado le diga al watchdog "esto es un shutdown limpio, no hagas nada".

## Cambios

- **`Sources/PryLib/Watchdog.swift`** (nuevo): loop del watchdog con dependency injection (`processAlive`, `sentinelExists`, `sleep`, `onCleanup`) para testeo unitario sin spawnear procesos reales ni dormir por segundos. Default `processAlive` usa `kill(pid, 0)` + `errno == ESRCH`. Default `onCleanup` hace `SystemProxy.disable` + `ProxyState.clear` + remove pid file.
- **`Sources/Pry/main.swift`**: nuevo subcomando `--watchdog <parent_pid>` despachado antes del switch principal (no corre `cleanupIfNeeded` — solo actúa si el padre muere).
- **`Sources/PryKit/ProxyManager.swift`**: 
  - `spawnWatchdog()` llamado al final de `start()` tras `enableSystemProxy()`
  - `shutdownWatchdog()` llamado al inicio de `stop()` (antes de disable, para evitar race con el watchdog)
  - Resolver del binario `pry`: sibling del ejecutable (dentro de `PryApp.app/Contents/MacOS/`), `/usr/local/bin/pry`, `/opt/homebrew/bin/pry`. Si nada existe: `fputs` warning y sigue — el watchdog es best-effort, no bloquea el start.
  - Propiedad pública `watchdogRunning: Bool` (observable) para que la UI pueda mostrar estado.
  - `WatchdogBox: @unchecked Sendable` para permitir terminate desde `deinit` fuera de MainActor.
  - `deinit` también llama shutdown del watchdog (belt-and-suspenders).
- **`Tests/PryLibTests/WatchdogTests.swift`** (nuevo): 8 tests unitarios. Usa DI con stubs, `pollInterval: 0.01` y `maxIterations` para determinismo.

## Test plan

- [x] `swift build` sin errores
- [x] `swift test --filter WatchdogTests` → 8/8 green
- [x] `swift test --filter PryKitTests` (ProxyManager cambió) → sin regresiones
- [x] `.build/debug/pry --watchdog 999999` → exits con `cleanupExecuted` en <1s
- [x] `.build/debug/pry --watchdog notanumber` → exit code 2, usage a stderr
- [x] `.build/debug/pry --watchdog` (sin arg) → exit code 2

## Verificación manual (post-merge)

1. **Force-quit (escenario del bug)**: abrir PryApp, Start → en terminal `ps aux | grep "pry --watchdog"` debería mostrar el watchdog. `kill -9 $(pgrep -x PryApp)`. Dentro de 3s el watchdog debería ver al padre muerto y ejecutar `SystemProxy.disable()`. Verificar con `networksetup -getwebproxy Wi-Fi` → `Enabled: No`. La red vuelve sin relanzar Pry.
2. **Stop ordenado**: Start → Stop desde la GUI. El watchdog debería recibir el sentinel, salir silenciosamente, y no quedar como zombie/orphan. `ps aux | grep watchdog` no debe mostrar nada.
3. **Crash**: correr PryApp bajo lldb, `call abort()`. Mismo resultado que force-quit (watchdog restaura proxy).
4. **Binario `pry` ausente**: correr el build de debug sin instalar en `/usr/local/bin` y sin sibling — se espera warning en stderr, `watchdogRunning = false`, pero `start()` sigue funcionando.

## Notas

- Sin nuevas deps SPM.
- CertificateAuthority, handlers NIO y TUI intactos.
- Sin label de release — es fix interno.