### PR TITLE
feat(PryApp): migrar StatusOverride al patrón ADR-006 (2a feature)

### DIFF
--- a/Sources/PryApp/Core/AppCore.swift
+++ b/Sources/PryApp/Core/AppCore.swift
@@ -33,6 +33,9 @@ public final class AppCore {
     /// Feature Blocking: lista de dominios bloqueados con matching + wildcards.
     public let blocks: BlockStore
 
+    /// Feature StatusOverrides: responde con status codes configurables por pattern.
+    public let statusOverrides: StatusOverridesStore
+
     public init() {
         let bus = EventBus()
         self.bus = bus
@@ -43,11 +46,16 @@ public final class AppCore {
         // ninguna feature importa PryLib directamente.
         StoragePaths.ensureRoot()
         self.blocks = BlockStore(storagePath: StoragePaths.blocksFile, bus: bus)
+        self.statusOverrides = StatusOverridesStore(storagePath: StoragePaths.overridesFile, bus: bus)
 
         // Registrar interceptors en la chain.
         let interceptors = self.interceptors
         let blocks = self.blocks
-        Task { await interceptors.register(BlockInterceptor(store: blocks)) }
+        let statusOverrides = self.statusOverrides
+        Task {
+            await interceptors.register(BlockInterceptor(store: blocks))
+            await interceptors.register(StatusOverrideInterceptor(store: statusOverrides))
+        }
     }
 
     /// Factory para `#Preview`. Genera un `AppCore` aislado sin efectos reales.
@@ -62,6 +70,17 @@ public final class AppCore {
     public static func previewWithBlockedDomains(_ domains: [String]) -> AppCore {
         let core = AppCore()
         for d in domains { core.blocks.add(d) }
+        return core
+    }
+
+    /// Factory de preview con `StatusOverridesStore` pre-poblado (útil para
+    /// `#Preview "with data"`). Simétrico a `previewWithBlockedDomains`.
+    @available(macOS 14, *)
+    public static func previewWithStatusOverrides(_ overrides: [(String, Int)]) -> AppCore {
+        let core = AppCore()
+        for (pattern, status) in overrides {
+            core.statusOverrides.add(pattern: pattern, status: status)
+        }
         return core
     }
 }

--- a/Sources/PryApp/Features/StatusOverrides/StatusOverrideInterceptor.swift
+++ b/Sources/PryApp/Features/StatusOverrides/StatusOverrideInterceptor.swift
@@ -1,0 +1,30 @@
+import Foundation
+import PryLib
+
+/// Interceptor de phase `.resolve` que responde con un status code configurable
+/// cuando la request matchea algún pattern en `StatusOverridesStore`. Corre después
+/// del `.gate` (Blocking) — si no lo bloqueó, quizá lo overridea.
+///
+/// Responde con un body JSON mínimo `{"x_pry_override":true}` para que los clientes
+/// puedan distinguir overrides sintéticos de responses reales durante debugging.
+@available(macOS 14, *)
+public struct StatusOverrideInterceptor: Interceptor {
+    public let phase: Phase = .resolve
+    private let store: StatusOverridesStore
+
+    public init(store: StatusOverridesStore) {
+        self.store = store
+    }
+
+    public func intercept(_ ctx: RequestContext) async -> InterceptResult {
+        let path = ctx.path
+        let host = ctx.host
+        let match = await MainActor.run { store.match(url: path, host: host) }
+        guard let status = match else { return .pass }
+        return .shortCircuit(Response(
+            status: status,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"x_pry_override":true}"#.utf8)
+        ))
+    }
+}

--- a/Sources/PryApp/Features/StatusOverrides/StatusOverridesStore.swift
+++ b/Sources/PryApp/Features/StatusOverrides/StatusOverridesStore.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Observation
+import PryLib
+
+/// Representa una regla de status override: un patrón que matchea URL/host +
+/// el status code con el que se debe responder inmediatamente.
+///
+/// Se persiste en formato `pattern\tstatus` por línea, compatible con el legacy
+/// `StatusOverrideStore` (PryLib) — ambos leen y escriben el mismo archivo cuando
+/// `AppCore` inyecta `StoragePaths.overridesFile`.
+public struct StatusOverride: Sendable, Equatable {
+    public let pattern: String
+    public let status: Int
+
+    public init(pattern: String, status: Int) {
+        self.pattern = pattern
+        self.status = status
+    }
+}
+
+/// Store de status overrides. Reemplaza progresivamente a `StatusOverrideStore`
+/// (PryLib legacy) en el contexto de PryApp.
+///
+/// Persiste a un archivo configurable (`AppCore.overridesStoragePath`). Formato:
+/// `pattern\tstatus` por línea, compatible con el legacy para coexistencia CLI.
+/// Soporta matching substring contra URL/host y patrones glob con `*`.
+@available(macOS 14, *)
+@Observable
+@MainActor
+public final class StatusOverridesStore {
+    /// Lista actual de overrides.
+    public private(set) var overrides: [StatusOverride] = []
+
+    private let storagePath: String
+    private let bus: EventBus
+
+    /// - Parameters:
+    ///   - storagePath: archivo donde persistir los overrides (formato `pattern\tstatus`).
+    ///     `AppCore` pasa el path canónico; los tests inyectan temp dirs.
+    ///   - bus: bus de eventos al que publicar `StatusOverridesChangedEvent` tras mutaciones.
+    public init(storagePath: String, bus: EventBus) {
+        self.storagePath = storagePath
+        self.bus = bus
+        reload()
+    }
+
+    // MARK: - Actions
+
+    /// Agrega un override. Trim automático. No-op si el pattern está vacío.
+    /// Si ya existe un override con el mismo pattern, lo reemplaza con el nuevo status.
+    public func add(pattern: String, status: Int) {
+        let sanitized = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitized.isEmpty else { return }
+        if let idx = overrides.firstIndex(where: { $0.pattern == sanitized }) {
+            // Dedup: mismo pattern reemplaza status.
+            guard overrides[idx].status != status else { return }
+            overrides[idx] = StatusOverride(pattern: sanitized, status: status)
+        } else {
+            overrides.append(StatusOverride(pattern: sanitized, status: status))
+        }
+        persist()
+        publishChange()
+    }
+
+    /// Quita el override con el pattern dado. No-op si no existe.
+    public func remove(pattern: String) {
+        let sanitized = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        let before = overrides.count
+        overrides.removeAll { $0.pattern == sanitized }
+        if overrides.count != before {
+            persist()
+            publishChange()
+        }
+    }
+
+    /// Vacía la lista completa.
+    public func clear() {
+        guard !overrides.isEmpty else { return }
+        overrides.removeAll()
+        persist()
+        publishChange()
+    }
+
+    private func publishChange() {
+        let snapshot = overrides.map { ($0.pattern, $0.status) }
+        let bus = self.bus
+        Task { await bus.publish(StatusOverridesChangedEvent(overrides: snapshot)) }
+    }
+
+    // MARK: - Matching
+
+    /// Retorna el status code si alguna regla matchea `url` o `host`.
+    ///
+    /// Reglas (replican el comportamiento del legacy `StatusOverrideStore.match`):
+    /// 1. Substring case-insensitive: si el pattern aparece en el URL o el host.
+    /// 2. Glob con `*`: se compila como regex y se matchea contra el URL completo.
+    ///
+    /// Retorna `nil` si ningún override aplica.
+    public func match(url: String, host: String) -> Int? {
+        let lowerURL = url.lowercased()
+        let lowerHost = host.lowercased()
+        for override in overrides {
+            let lowerPattern = override.pattern.lowercased()
+            // Substring match contra URL o host.
+            if lowerURL.contains(lowerPattern) || lowerHost.contains(lowerPattern) {
+                return override.status
+            }
+            // Glob con `*` → regex anclado.
+            if override.pattern.contains("*") {
+                let escaped = NSRegularExpression.escapedPattern(for: override.pattern)
+                let regexString = "^" + escaped.replacingOccurrences(of: "\\*", with: ".*") + "$"
+                if let re = try? NSRegularExpression(pattern: regexString, options: [.caseInsensitive]),
+                   re.firstMatch(in: url, range: NSRange(url.startIndex..., in: url)) != nil {
+                    return override.status
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Persistence
+
+    private func reload() {
+        guard let content = try? String(contentsOfFile: storagePath, encoding: .utf8) else {
+            overrides = []
+            return
+        }
+        overrides = content
+            .split(separator: "\n")
+            .compactMap { line in
+                let parts = line.split(separator: "\t", maxSplits: 1)
+                guard parts.count == 2, let status = Int(parts[1]) else { return nil }
+                return StatusOverride(pattern: String(parts[0]), status: status)
+            }
+    }
+
+    private func persist() {
+        let content = overrides.map { "\($0.pattern)\t\($0.status)" }.joined(separator: "\n")
+        let toWrite = overrides.isEmpty ? "" : content + "\n"
+        try? toWrite.write(toFile: storagePath, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/PryApp/Features/StatusOverrides/StatusOverridesView.swift
+++ b/Sources/PryApp/Features/StatusOverrides/StatusOverridesView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// UI para gestionar la lista de status overrides. Consume `StatusOverridesStore`
+/// via `AppCore` inyectado en `@Environment`.
+@available(macOS 14, *)
+struct StatusOverridesView: View {
+    @Environment(AppCore.self) private var core
+
+    @State private var newPattern: String = ""
+    @State private var newStatus: Int = 500
+
+    /// Status codes de HTTP más comunes para testing de error UI.
+    private static let commonStatuses: [Int] = [400, 401, 403, 404, 418, 500, 502, 503, 504]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header con input para agregar.
+            HStack {
+                TextField("URL pattern (ej. /api/login o */checkout*)", text: $newPattern)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { addCurrent() }
+                Picker("Status", selection: $newStatus) {
+                    ForEach(Self.commonStatuses, id: \.self) { code in
+                        Text("\(code)").tag(code)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 90)
+                Button("Add") { addCurrent() }
+                    .disabled(newPattern.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+
+            Divider()
+
+            // Lista de overrides.
+            if core.statusOverrides.overrides.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "arrow.up.right.diamond")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.secondary)
+                    Text("No hay status overrides")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(core.statusOverrides.overrides, id: \.pattern) { override in
+                        HStack {
+                            Image(systemName: "arrow.up.right.diamond.fill")
+                                .foregroundStyle(color(for: override.status))
+                            Text(override.pattern)
+                            Spacer()
+                            Text("\(override.status)")
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(color(for: override.status))
+                            Button {
+                                core.statusOverrides.remove(pattern: override.pattern)
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Status Overrides")
+    }
+
+    @MainActor
+    private func addCurrent() {
+        let trimmed = newPattern.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        core.statusOverrides.add(pattern: trimmed, status: newStatus)
+        newPattern = ""
+    }
+
+    /// Color visual según familia de status: 4xx amarillo, 5xx rojo, resto neutro.
+    private func color(for status: Int) -> Color {
+        switch status {
+        case 500...599: return .red.opacity(0.85)
+        case 400...499: return .orange.opacity(0.85)
+        default: return .secondary
+        }
+    }
+}
+
+// Previews usan el estilo viejo (PreviewProvider) porque el macro `#Preview` no
+// soporta `@available` y el package apunta a macOS 13 para mantener compatibilidad
+// con la CLI. Los PreviewProviders permiten gating por availability de forma limpia.
+@available(macOS 14, *)
+struct StatusOverridesView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            StatusOverridesView()
+                .environment(AppCore.preview())
+                .previewDisplayName("empty")
+
+            StatusOverridesView()
+                .environment(AppCore.previewWithStatusOverrides([
+                    ("/api/login", 500),
+                    ("*/checkout*", 503),
+                    ("/api/search", 429)
+                ]))
+                .previewDisplayName("with data")
+        }
+        .frame(width: 500, height: 400)
+    }
+}

--- a/Sources/PryApp/MainWindow.swift
+++ b/Sources/PryApp/MainWindow.swift
@@ -15,6 +15,7 @@ struct MainWindow: View {
     @State private var showRules = false
     @State private var showDeviceSetup = false
     @State private var showBlocking = false
+    @State private var showOverrides = false
     @State private var sidebarWidth: CGFloat = 220
     @State private var detailHeight: CGFloat = 280
     @State private var showSidebar = true
@@ -142,12 +143,21 @@ struct MainWindow: View {
                     Text("Blocking")
                 }
             }
+            ToolbarItem(placement: .automatic) {
+                Button { showOverrides.toggle() } label: {
+                    Image(systemName: "arrow.up.right.diamond.fill")
+                    Text("Overrides")
+                }
+            }
         }
         .sheet(isPresented: $showMocking) {
             UnifiedMockView().frame(minWidth: 800, minHeight: 500)
         }
         .sheet(isPresented: $showBlocking) {
             BlocksView().frame(minWidth: 500, minHeight: 400)
+        }
+        .sheet(isPresented: $showOverrides) {
+            StatusOverridesView().frame(minWidth: 500, minHeight: 400)
         }
         .sheet(isPresented: $showBreakpoints) {
             BreakpointListView().frame(minWidth: 500, minHeight: 400)

--- a/Sources/PryLib/Interceptors/Events.swift
+++ b/Sources/PryLib/Interceptors/Events.swift
@@ -102,3 +102,17 @@ public struct BlockListChangedEvent: PryEvent {
         self.changedAt = changedAt
     }
 }
+
+/// Emitido cuando la lista de status overrides cambia (add/remove/clear).
+/// Consumers: UI de otras features, métricas, futuras integraciones.
+///
+/// El payload lleva la lista actual de `(pattern, status)` — sin cuerpos ni metadata
+/// adicional — siguiendo la convención de eventos livianos del `EventBus`.
+public struct StatusOverridesChangedEvent: PryEvent {
+    public let overrides: [(String, Int)]
+    public let changedAt: Date
+    public init(overrides: [(String, Int)], changedAt: Date = Date()) {
+        self.overrides = overrides
+        self.changedAt = changedAt
+    }
+}

--- a/Tests/PryAppTests/Features/StatusOverrides/StatusOverrideInterceptorTests.swift
+++ b/Tests/PryAppTests/Features/StatusOverrides/StatusOverrideInterceptorTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import PryApp
+import PryLib
+
+@available(macOS 14, *)
+final class StatusOverrideInterceptorTests: XCTestCase {
+    var store: StatusOverridesStore!
+    var bus: EventBus!
+    var sut: StatusOverrideInterceptor!
+    var tempDir: URL!
+
+    @MainActor
+    override func setUp() async throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        bus = EventBus()
+        store = StatusOverridesStore(
+            storagePath: tempDir.appendingPathComponent("overrides").path,
+            bus: bus
+        )
+        sut = StatusOverrideInterceptor(store: store)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - phase
+
+    func test_phase_isResolve() {
+        XCTAssertEqual(sut.phase, .resolve)
+    }
+
+    // MARK: - pass
+
+    func test_pass_whenNoMatch() async {
+        // store vacío → ningún pattern matchea.
+        let ctx = RequestContext(method: "GET", host: "example.com", path: "/api/users")
+        let result = await sut.intercept(ctx)
+        switch result {
+        case .pass:
+            break
+        default:
+            XCTFail("esperaba .pass cuando no matchea, obtuvo \(result)")
+        }
+    }
+
+    // MARK: - shortCircuit
+
+    @MainActor
+    func test_shortCircuit_withMatchedStatus() async {
+        store.add(pattern: "/api/login", status: 500)
+        let ctx = RequestContext(method: "POST", host: "example.com", path: "/api/login")
+        let result = await sut.intercept(ctx)
+        switch result {
+        case .shortCircuit(let response):
+            XCTAssertEqual(response.status, 500)
+        default:
+            XCTFail("esperaba .shortCircuit(500), obtuvo \(result)")
+        }
+    }
+
+    @MainActor
+    func test_shortCircuit_preservesStatusValue() async {
+        store.add(pattern: "/api/search", status: 429)
+        let ctx = RequestContext(method: "GET", host: "example.com", path: "/api/search?q=x")
+        let result = await sut.intercept(ctx)
+        switch result {
+        case .shortCircuit(let response):
+            XCTAssertEqual(response.status, 429)
+            XCTAssertEqual(response.headers["Content-Type"], "application/json")
+            XCTAssertNotNil(response.body)
+            if let body = response.body, let str = String(data: body, encoding: .utf8) {
+                XCTAssertTrue(str.contains("x_pry_override"))
+            } else {
+                XCTFail("body should be decodable JSON")
+            }
+        default:
+            XCTFail("esperaba .shortCircuit(429), obtuvo \(result)")
+        }
+    }
+
+    @MainActor
+    func test_shortCircuit_matchesHost() async {
+        store.add(pattern: "tracker.com", status: 503)
+        let ctx = RequestContext(method: "GET", host: "ads.tracker.com", path: "/beacon")
+        let result = await sut.intercept(ctx)
+        switch result {
+        case .shortCircuit(let response):
+            XCTAssertEqual(response.status, 503)
+        default:
+            XCTFail("esperaba .shortCircuit(503) por match de host, obtuvo \(result)")
+        }
+    }
+}

--- a/Tests/PryAppTests/Features/StatusOverrides/StatusOverridesStoreTests.swift
+++ b/Tests/PryAppTests/Features/StatusOverrides/StatusOverridesStoreTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import PryApp
+import PryLib
+
+@available(macOS 14, *)
+final class StatusOverridesStoreTests: XCTestCase {
+    var store: StatusOverridesStore!
+    var bus: EventBus!
+    var tempDir: URL!
+    var storagePath: String!
+
+    @MainActor
+    override func setUp() async throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        storagePath = tempDir.appendingPathComponent("overrides").path
+        bus = EventBus()
+        store = StatusOverridesStore(storagePath: storagePath, bus: bus)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - add
+
+    @MainActor
+    func test_add_appendsOverride() {
+        XCTAssertTrue(store.overrides.isEmpty)
+        store.add(pattern: "/api/login", status: 500)
+        XCTAssertEqual(store.overrides.count, 1)
+        XCTAssertEqual(store.overrides[0].pattern, "/api/login")
+        XCTAssertEqual(store.overrides[0].status, 500)
+    }
+
+    @MainActor
+    func test_add_trimsWhitespace() {
+        store.add(pattern: "  /api/login  \n", status: 500)
+        XCTAssertEqual(store.overrides.first?.pattern, "/api/login")
+    }
+
+    @MainActor
+    func test_add_ignoresEmpty() {
+        store.add(pattern: "", status: 500)
+        store.add(pattern: "   ", status: 500)
+        XCTAssertTrue(store.overrides.isEmpty)
+    }
+
+    @MainActor
+    func test_add_dedupReplacesStatus() {
+        store.add(pattern: "/api/login", status: 500)
+        store.add(pattern: "/api/login", status: 502)
+        XCTAssertEqual(store.overrides.count, 1)
+        XCTAssertEqual(store.overrides[0].status, 502)
+    }
+
+    // MARK: - remove / clear
+
+    @MainActor
+    func test_remove_removesOverride() {
+        store.add(pattern: "/a", status: 500)
+        store.add(pattern: "/b", status: 502)
+        store.remove(pattern: "/a")
+        XCTAssertEqual(store.overrides.count, 1)
+        XCTAssertEqual(store.overrides[0].pattern, "/b")
+    }
+
+    @MainActor
+    func test_clear_emptiesList() {
+        store.add(pattern: "/a", status: 500)
+        store.add(pattern: "/b", status: 502)
+        store.clear()
+        XCTAssertTrue(store.overrides.isEmpty)
+    }
+
+    // MARK: - match — exact path substring
+
+    @MainActor
+    func test_match_exactPathSubstring() {
+        store.add(pattern: "/api/login", status: 500)
+        XCTAssertEqual(store.match(url: "/api/login", host: "example.com"), 500)
+        XCTAssertEqual(store.match(url: "/api/login?x=1", host: "example.com"), 500)
+    }
+
+    @MainActor
+    func test_match_noMatchReturnsNil() {
+        store.add(pattern: "/api/login", status: 500)
+        XCTAssertNil(store.match(url: "/api/logout", host: "example.com"))
+    }
+
+    // MARK: - match — glob
+
+    @MainActor
+    func test_match_globSubstringFallback() {
+        // `*/checkout*` contiene la substring "/checkout" que matchea directo.
+        store.add(pattern: "*/checkout*", status: 503)
+        XCTAssertEqual(store.match(url: "/api/checkout/step1", host: "shop.com"), 503)
+    }
+
+    @MainActor
+    func test_match_globAgainstURL() {
+        // Sin la substring directa, el branch glob anclado compila regex.
+        store.add(pattern: "*admin*", status: 403)
+        XCTAssertEqual(store.match(url: "/panel/admin/users", host: "site.com"), 403)
+    }
+
+    // MARK: - match — host
+
+    @MainActor
+    func test_match_host() {
+        store.add(pattern: "tracker.com", status: 404)
+        XCTAssertEqual(store.match(url: "/pixel.gif", host: "ads.tracker.com"), 404)
+    }
+
+    @MainActor
+    func test_match_caseInsensitive() {
+        store.add(pattern: "/API/Login", status: 500)
+        XCTAssertEqual(store.match(url: "/api/login", host: "example.com"), 500)
+    }
+
+    // MARK: - persistence
+
+    @MainActor
+    func test_persistence_survivesReload() {
+        store.add(pattern: "/api/login", status: 500)
+        store.add(pattern: "/api/pay", status: 502)
+        let reloaded = StatusOverridesStore(storagePath: storagePath, bus: bus)
+        XCTAssertEqual(reloaded.overrides.count, 2)
+        XCTAssertEqual(reloaded.overrides[0].pattern, "/api/login")
+        XCTAssertEqual(reloaded.overrides[0].status, 500)
+        XCTAssertEqual(reloaded.overrides[1].pattern, "/api/pay")
+        XCTAssertEqual(reloaded.overrides[1].status, 502)
+    }
+
+    @MainActor
+    func test_persistence_clearPersists() {
+        store.add(pattern: "/a", status: 500)
+        store.clear()
+        let reloaded = StatusOverridesStore(storagePath: storagePath, bus: bus)
+        XCTAssertTrue(reloaded.overrides.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

2a feature migrada al patrón del ADR-006. Valida que el template escala: mismo approach que Blocking (PR #132) copiado y adaptado — confirma que agregar una feature es repetible.

## Semántica

User define pares (url_pattern, status_code). Requests que matcheen retornan inmediatamente con ese status + body JSON `{"x_pry_override": true}`. Útil para testear UIs de error (forzar 500 en `/api/login`, 403 en `/admin`, etc).

## Archivos

### Nuevos
- `Sources/PryApp/Features/StatusOverrides/StatusOverridesStore.swift` — @Observable @MainActor, persistencia, publica evento al bus
- `Sources/PryApp/Features/StatusOverrides/StatusOverrideInterceptor.swift` — phase .resolve, shortCircuit con Response custom
- `Sources/PryApp/Features/StatusOverrides/StatusOverridesView.swift` — SwiftUI + 2 PreviewProviders
- `Tests/PryAppTests/Features/StatusOverrides/StatusOverridesStoreTests.swift` — 13 tests
- `Tests/PryAppTests/Features/StatusOverrides/StatusOverrideInterceptorTests.swift` — 5 tests

### Modificados
- `Sources/PryLib/Interceptors/Events.swift` — `StatusOverridesChangedEvent`
- `Sources/PryApp/Core/AppCore.swift` — instancia + registra interceptor
- `Sources/PryApp/MainWindow.swift` — toolbar item + sheet

### Intacto
- `Sources/PryLib/StatusOverrideStore.swift` — legacy, CLI sigue usándolo
- `Sources/PryLib/HTTPInterceptor.swift`, `ConnectHandler.swift` — chequeo legacy redundante, se quita en PR de higiene

## Verificación

- `swift build` clean, no warnings
- `swift test` → 285 pass, 0 fail
- `swift test --filter StatusOverride` → 20+ tests nuevos + legacy tests, todos pasan

## Test plan manual

1. Start proxy → Toolbar "Overrides"
2. Agregar pattern `/api/login` con status 500 → Add
3. `curl -x http://localhost:8080 http://example.com/api/login`
4. Debe responder 500 con `{"x_pry_override": true}` en body
5. Log muestra prefix `(chain)` indicando que vino del path nuevo

🤖 Generated with [Claude Code](https://claude.com/claude-code)