### PR TITLE
feat(PryApp): migrar MapLocal al patrón ADR-006 (3a feature)

### DIFF
--- a/Sources/PryApp/Core/AppCore.swift
+++ b/Sources/PryApp/Core/AppCore.swift
@@ -36,6 +36,11 @@ public final class AppCore {
     /// Feature StatusOverrides: responde con status codes configurables por pattern.
     public let statusOverrides: StatusOverridesStore
 
+    /// Feature MapLocal: responde con el contenido de un archivo local cuando la
+    /// URL matchea un pattern regex. Útil para reemplazar assets remotos con
+    /// versiones locales durante dev.
+    public let mapLocal: MapLocalStore
+
     public init() {
         let bus = EventBus()
         self.bus = bus
@@ -47,14 +52,17 @@ public final class AppCore {
         StoragePaths.ensureRoot()
         self.blocks = BlockStore(storagePath: StoragePaths.blocksFile, bus: bus)
         self.statusOverrides = StatusOverridesStore(storagePath: StoragePaths.overridesFile, bus: bus)
+        self.mapLocal = MapLocalStore(storagePath: StoragePaths.mapsFile, bus: bus)
 
         // Registrar interceptors en la chain.
         let interceptors = self.interceptors
         let blocks = self.blocks
         let statusOverrides = self.statusOverrides
+        let mapLocal = self.mapLocal
         Task {
             await interceptors.register(BlockInterceptor(store: blocks))
             await interceptors.register(StatusOverrideInterceptor(store: statusOverrides))
+            await interceptors.register(MapLocalInterceptor(store: mapLocal))
         }
     }
 
@@ -80,6 +88,16 @@ public final class AppCore {
         let core = AppCore()
         for (pattern, status) in overrides {
             core.statusOverrides.add(pattern: pattern, status: status)
+        }
+        return core
+    }
+
+    /// Factory de preview con `MapLocalStore` pre-poblado. Simétrico al resto.
+    @available(macOS 14, *)
+    public static func previewWithMapLocalMappings(_ mappings: [(String, String)]) -> AppCore {
+        let core = AppCore()
+        for (pattern, path) in mappings {
+            core.mapLocal.add(pattern: pattern, filePath: path)
         }
         return core
     }

--- a/Sources/PryApp/Features/MapLocal/MapLocalInterceptor.swift
+++ b/Sources/PryApp/Features/MapLocal/MapLocalInterceptor.swift
@@ -1,0 +1,56 @@
+import Foundation
+import PryLib
+
+/// Interceptor de phase `.resolve` que responde con el contenido de un archivo
+/// local cuando la URL matchea algún pattern en `MapLocalStore`. Corre después
+/// del `.gate` (Blocking) — si no lo bloquearon, quizá lo mapee a un archivo.
+///
+/// El Content-Type se infiere de la extensión del archivo (ver `contentType(for:)`).
+/// Si el archivo no existe o no se puede leer, responde con `.notFound()` para
+/// señalizar que el mapping está roto sin ir al servidor real.
+@available(macOS 14, *)
+public struct MapLocalInterceptor: Interceptor {
+    public let phase: Phase = .resolve
+    private let store: MapLocalStore
+
+    public init(store: MapLocalStore) {
+        self.store = store
+    }
+
+    public func intercept(_ ctx: RequestContext) async -> InterceptResult {
+        let fullURL = ctx.host + ctx.path
+        let matched = await MainActor.run { store.match(url: fullURL) }
+        guard let filePath = matched else { return .pass }
+
+        let resolved = (filePath as NSString).standardizingPath
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: resolved)) else {
+            return .shortCircuit(.notFound())
+        }
+
+        return .shortCircuit(Response(
+            status: 200,
+            headers: ["Content-Type": contentType(for: resolved)],
+            body: data
+        ))
+    }
+}
+
+/// Infiere el Content-Type a partir de la extensión del archivo. Cubre los tipos
+/// más comunes en dev (JSON, JS, HTML, CSS, imágenes). Default `application/octet-stream`
+/// para extensiones desconocidas — el cliente debe saber qué esperar.
+@available(macOS 14, *)
+func contentType(for path: String) -> String {
+    let ext = (path as NSString).pathExtension.lowercased()
+    switch ext {
+    case "json": return "application/json"
+    case "js":   return "application/javascript"
+    case "css":  return "text/css"
+    case "html", "htm": return "text/html"
+    case "xml":  return "application/xml"
+    case "txt":  return "text/plain"
+    case "svg":  return "image/svg+xml"
+    case "png":  return "image/png"
+    case "jpg", "jpeg": return "image/jpeg"
+    default:     return "application/octet-stream"
+    }
+}

--- a/Sources/PryApp/Features/MapLocal/MapLocalStore.swift
+++ b/Sources/PryApp/Features/MapLocal/MapLocalStore.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Observation
+import PryLib
+
+/// Representa una regla Map Local: un patrón regex que matchea contra la URL
+/// entrante y un path de archivo local cuyo contenido se devuelve como respuesta.
+///
+/// Se persiste en formato `pattern\tfilePath` por línea, compatible con el legacy
+/// `MapLocal` (PryLib) — ambos leen y escriben el mismo archivo cuando
+/// `AppCore` inyecta `StoragePaths.mapsFile`.
+public struct MapLocalMapping: Sendable, Equatable {
+    public let pattern: String
+    public let filePath: String
+
+    public init(pattern: String, filePath: String) {
+        self.pattern = pattern
+        self.filePath = filePath
+    }
+}
+
+/// Store de mappings Map Local. Reemplaza progresivamente a `MapLocal`
+/// (PryLib legacy) en el contexto de PryApp.
+///
+/// Persiste a un archivo configurable (`AppCore.mapsStoragePath`). Formato:
+/// `pattern\tfilePath` por línea, compatible con el legacy para coexistencia CLI.
+/// `match(url:)` retorna el path del archivo mapeado (no el contenido) — la
+/// lectura real la hace el interceptor, que también infiere Content-Type.
+@available(macOS 14, *)
+@Observable
+@MainActor
+public final class MapLocalStore {
+    /// Lista actual de mappings.
+    public private(set) var mappings: [MapLocalMapping] = []
+
+    private let storagePath: String
+    private let bus: EventBus
+
+    /// - Parameters:
+    ///   - storagePath: archivo donde persistir los mappings (formato `pattern\tfilePath`).
+    ///     `AppCore` pasa el path canónico; los tests inyectan temp dirs.
+    ///   - bus: bus de eventos al que publicar `MapLocalChangedEvent` tras mutaciones.
+    public init(storagePath: String, bus: EventBus) {
+        self.storagePath = storagePath
+        self.bus = bus
+        reload()
+    }
+
+    // MARK: - Actions
+
+    /// Agrega un mapping. Trim automático del pattern. No-op si el pattern o el
+    /// filePath están vacíos. Si ya existe un mapping con el mismo pattern, lo
+    /// reemplaza con el nuevo filePath.
+    public func add(pattern: String, filePath: String) {
+        let sanitizedPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedPath = filePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitizedPattern.isEmpty, !sanitizedPath.isEmpty else { return }
+        if let idx = mappings.firstIndex(where: { $0.pattern == sanitizedPattern }) {
+            guard mappings[idx].filePath != sanitizedPath else { return }
+            mappings[idx] = MapLocalMapping(pattern: sanitizedPattern, filePath: sanitizedPath)
+        } else {
+            mappings.append(MapLocalMapping(pattern: sanitizedPattern, filePath: sanitizedPath))
+        }
+        persist()
+        publishChange()
+    }
+
+    /// Quita el mapping con el pattern dado. No-op si no existe.
+    public func remove(pattern: String) {
+        let sanitized = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        let before = mappings.count
+        mappings.removeAll { $0.pattern == sanitized }
+        if mappings.count != before {
+            persist()
+            publishChange()
+        }
+    }
+
+    /// Vacía la lista completa.
+    public func clear() {
+        guard !mappings.isEmpty else { return }
+        mappings.removeAll()
+        persist()
+        publishChange()
+    }
+
+    private func publishChange() {
+        let snapshot = mappings.map { ($0.pattern, $0.filePath) }
+        let bus = self.bus
+        Task { await bus.publish(MapLocalChangedEvent(mappings: snapshot)) }
+    }
+
+    // MARK: - Matching
+
+    /// Retorna el filePath asociado al primer mapping cuyo pattern matchea `url`.
+    ///
+    /// Reglas (replican el comportamiento del legacy `MapLocal.match`):
+    /// 1. El pattern se compila como `NSRegularExpression` y se aplica al URL completo.
+    /// 2. Si la compilación falla, ese mapping se ignora.
+    ///
+    /// Retorna `nil` si ningún mapping aplica.
+    public func match(url: String) -> String? {
+        for mapping in mappings {
+            guard let regex = try? NSRegularExpression(pattern: mapping.pattern) else { continue }
+            let range = NSRange(url.startIndex..., in: url)
+            if regex.firstMatch(in: url, range: range) != nil {
+                return mapping.filePath
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Persistence
+
+    private func reload() {
+        guard let content = try? String(contentsOfFile: storagePath, encoding: .utf8) else {
+            mappings = []
+            return
+        }
+        mappings = content
+            .split(separator: "\n")
+            .compactMap { line in
+                let parts = line.split(separator: "\t", maxSplits: 1)
+                guard parts.count == 2 else { return nil }
+                let pattern = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+                let path = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !pattern.isEmpty, !path.isEmpty else { return nil }
+                return MapLocalMapping(pattern: pattern, filePath: path)
+            }
+    }
+
+    private func persist() {
+        let content = mappings.map { "\($0.pattern)\t\($0.filePath)" }.joined(separator: "\n")
+        let toWrite = mappings.isEmpty ? "" : content + "\n"
+        try? toWrite.write(toFile: storagePath, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/PryApp/Features/MapLocal/MapLocalView.swift
+++ b/Sources/PryApp/Features/MapLocal/MapLocalView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import AppKit
+
+/// UI para gestionar mappings de Map Local. Consume `MapLocalStore` via
+/// `AppCore` inyectado en `@Environment`.
+@available(macOS 14, *)
+struct MapLocalView: View {
+    @Environment(AppCore.self) private var core
+
+    @State private var newPattern: String = ""
+    @State private var newFilePath: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header con inputs para agregar.
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("URL regex (ej. ^https://api\\.example\\.com/users$)", text: $newPattern)
+                    .textFieldStyle(.roundedBorder)
+                HStack {
+                    TextField("Path al archivo local", text: $newFilePath)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Pick file…") { pickFile() }
+                    Button("Add") { addCurrent() }
+                        .disabled(!canAdd)
+                }
+            }
+            .padding()
+
+            Divider()
+
+            // Lista de mappings.
+            if core.mapLocal.mappings.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.secondary)
+                    Text("No hay mappings de Map Local")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(core.mapLocal.mappings, id: \.pattern) { mapping in
+                        HStack(alignment: .top) {
+                            Image(systemName: "arrow.right.doc.on.clipboard")
+                                .foregroundStyle(.blue.opacity(0.8))
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(mapping.pattern)
+                                    .font(.system(.body, design: .monospaced))
+                                Text(mapping.filePath)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                            Spacer()
+                            Button {
+                                core.mapLocal.remove(pattern: mapping.pattern)
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Map Local")
+    }
+
+    private var canAdd: Bool {
+        !newPattern.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !newFilePath.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    @MainActor
+    private func addCurrent() {
+        let pattern = newPattern.trimmingCharacters(in: .whitespaces)
+        let path = newFilePath.trimmingCharacters(in: .whitespaces)
+        guard !pattern.isEmpty, !path.isEmpty else { return }
+        core.mapLocal.add(pattern: pattern, filePath: path)
+        newPattern = ""
+        newFilePath = ""
+    }
+
+    private func pickFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            newFilePath = url.path
+        }
+    }
+}
+
+// Previews usan PreviewProvider (no el macro #Preview) porque el package
+// target es macOS 13 y el macro no permite @available(macOS 14, *).
+@available(macOS 14, *)
+struct MapLocalView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            MapLocalView()
+                .environment(AppCore.preview())
+                .previewDisplayName("empty")
+
+            MapLocalView()
+                .environment(AppCore.previewWithMapLocalMappings([
+                    ("^https://api\\.example\\.com/users$", "/tmp/users.json"),
+                    (".*\\.analytics\\.com.*", "/tmp/empty.json")
+                ]))
+                .previewDisplayName("with data")
+        }
+        .frame(width: 500, height: 400)
+    }
+}

--- a/Sources/PryApp/MainWindow.swift
+++ b/Sources/PryApp/MainWindow.swift
@@ -16,6 +16,7 @@ struct MainWindow: View {
     @State private var showDeviceSetup = false
     @State private var showBlocking = false
     @State private var showOverrides = false
+    @State private var showMapLocal = false
     @State private var sidebarWidth: CGFloat = 220
     @State private var detailHeight: CGFloat = 280
     @State private var showSidebar = true
@@ -149,6 +150,12 @@ struct MainWindow: View {
                     Text("Overrides")
                 }
             }
+            ToolbarItem(placement: .automatic) {
+                Button { showMapLocal.toggle() } label: {
+                    Image(systemName: "doc.text")
+                    Text("Map Local")
+                }
+            }
         }
         .sheet(isPresented: $showMocking) {
             UnifiedMockView().frame(minWidth: 800, minHeight: 500)
@@ -158,6 +165,9 @@ struct MainWindow: View {
         }
         .sheet(isPresented: $showOverrides) {
             StatusOverridesView().frame(minWidth: 500, minHeight: 400)
+        }
+        .sheet(isPresented: $showMapLocal) {
+            MapLocalView().frame(minWidth: 600, minHeight: 450)
         }
         .sheet(isPresented: $showBreakpoints) {
             BreakpointListView().frame(minWidth: 500, minHeight: 400)

--- a/Sources/PryLib/Interceptors/Events.swift
+++ b/Sources/PryLib/Interceptors/Events.swift
@@ -116,3 +116,15 @@ public struct StatusOverridesChangedEvent: PryEvent {
         self.changedAt = changedAt
     }
 }
+
+/// Emitido cuando la lista de mappings de MapLocal cambia.
+/// Consumers: UI, futuras integraciones.
+/// Payload: `(pattern, filePath)` para cada mapping.
+public struct MapLocalChangedEvent: PryEvent {
+    public let mappings: [(String, String)]
+    public let changedAt: Date
+    public init(mappings: [(String, String)], changedAt: Date = Date()) {
+        self.mappings = mappings
+        self.changedAt = changedAt
+    }
+}

--- a/Tests/PryAppTests/Features/MapLocal/MapLocalInterceptorTests.swift
+++ b/Tests/PryAppTests/Features/MapLocal/MapLocalInterceptorTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import PryApp
+import PryLib
+
+@available(macOS 14, *)
+final class MapLocalInterceptorTests: XCTestCase {
+    var store: MapLocalStore!
+    var bus: EventBus!
+    var sut: MapLocalInterceptor!
+    var tempDir: URL!
+
+    @MainActor
+    override func setUp() async throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        bus = EventBus()
+        store = MapLocalStore(
+            storagePath: tempDir.appendingPathComponent("maps").path,
+            bus: bus
+        )
+        sut = MapLocalInterceptor(store: store)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func test_phase_isResolve() {
+        XCTAssertEqual(sut.phase, .resolve)
+    }
+
+    func test_pass_whenNoMatch() async {
+        let ctx = RequestContext(method: "GET", host: "example.com", path: "/api")
+        let result = await sut.intercept(ctx)
+        guard case .pass = result else {
+            XCTFail("esperaba .pass, obtuvo \(result)"); return
+        }
+    }
+
+    @MainActor
+    func test_shortCircuit_withFileContent() async {
+        let jsonPath = tempDir.appendingPathComponent("users.json").path
+        let jsonContent = #"{"users":[{"id":1,"name":"Alice"}]}"#
+        try? jsonContent.write(toFile: jsonPath, atomically: true, encoding: .utf8)
+
+        store.add(pattern: ".*/api/users$", filePath: jsonPath)
+        let ctx = RequestContext(method: "GET", host: "example.com", path: "/api/users")
+        let result = await sut.intercept(ctx)
+
+        guard case .shortCircuit(let response) = result else {
+            XCTFail("esperaba .shortCircuit, obtuvo \(result)"); return
+        }
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(response.headers["Content-Type"], "application/json")
+        XCTAssertEqual(String(data: response.body ?? Data(), encoding: .utf8), jsonContent)
+    }
+
+    @MainActor
+    func test_shortCircuit_withNotFoundWhenFileMissing() async {
+        store.add(pattern: ".*", filePath: "/definitely/does/not/exist.json")
+        let ctx = RequestContext(method: "GET", host: "example.com", path: "/anything")
+        let result = await sut.intercept(ctx)
+        guard case .shortCircuit(let response) = result else {
+            XCTFail("esperaba .shortCircuit(.notFound), obtuvo \(result)"); return
+        }
+        XCTAssertEqual(response.status, 404)
+    }
+
+    @MainActor
+    func test_contentType_inferredFromExtension() async {
+        let cases: [(ext: String, expected: String)] = [
+            ("json", "application/json"),
+            ("js", "application/javascript"),
+            ("css", "text/css"),
+            ("html", "text/html"),
+            ("svg", "image/svg+xml"),
+            ("png", "image/png")
+        ]
+        for tc in cases {
+            let path = tempDir.appendingPathComponent("f.\(tc.ext)").path
+            try? "x".write(toFile: path, atomically: true, encoding: .utf8)
+            store.clear()
+            store.add(pattern: ".*", filePath: path)
+            let ctx = RequestContext(method: "GET", host: "a", path: "/")
+            let result = await sut.intercept(ctx)
+            guard case .shortCircuit(let response) = result else {
+                XCTFail("no shortCircuit para .\(tc.ext)"); continue
+            }
+            XCTAssertEqual(response.headers["Content-Type"], tc.expected, "ext: .\(tc.ext)")
+        }
+    }
+}

--- a/Tests/PryAppTests/Features/MapLocal/MapLocalStoreTests.swift
+++ b/Tests/PryAppTests/Features/MapLocal/MapLocalStoreTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import PryApp
+import PryLib
+
+@available(macOS 14, *)
+final class MapLocalStoreTests: XCTestCase {
+    var store: MapLocalStore!
+    var bus: EventBus!
+    var tempDir: URL!
+    var storagePath: String!
+
+    @MainActor
+    override func setUp() async throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        storagePath = tempDir.appendingPathComponent("maps").path
+        bus = EventBus()
+        store = MapLocalStore(storagePath: storagePath, bus: bus)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - add
+
+    @MainActor
+    func test_add_appendsMapping() {
+        XCTAssertTrue(store.mappings.isEmpty)
+        store.add(pattern: "^https://api\\.example\\.com$", filePath: "/tmp/users.json")
+        XCTAssertEqual(store.mappings.count, 1)
+        XCTAssertEqual(store.mappings[0].pattern, "^https://api\\.example\\.com$")
+        XCTAssertEqual(store.mappings[0].filePath, "/tmp/users.json")
+    }
+
+    @MainActor
+    func test_add_trimsWhitespace() {
+        store.add(pattern: "  /api/users  ", filePath: "  /tmp/x.json  \n")
+        XCTAssertEqual(store.mappings[0].pattern, "/api/users")
+        XCTAssertEqual(store.mappings[0].filePath, "/tmp/x.json")
+    }
+
+    @MainActor
+    func test_add_ignoresEmpty() {
+        store.add(pattern: "", filePath: "/tmp/x.json")
+        store.add(pattern: "/api", filePath: "")
+        XCTAssertTrue(store.mappings.isEmpty)
+    }
+
+    @MainActor
+    func test_add_replacesExistingPattern() {
+        store.add(pattern: "/api", filePath: "/tmp/a.json")
+        store.add(pattern: "/api", filePath: "/tmp/b.json")
+        XCTAssertEqual(store.mappings.count, 1)
+        XCTAssertEqual(store.mappings[0].filePath, "/tmp/b.json")
+    }
+
+    // MARK: - remove / clear
+
+    @MainActor
+    func test_remove_removesMapping() {
+        store.add(pattern: "/a", filePath: "/tmp/a")
+        store.add(pattern: "/b", filePath: "/tmp/b")
+        store.remove(pattern: "/a")
+        XCTAssertEqual(store.mappings.count, 1)
+        XCTAssertEqual(store.mappings[0].pattern, "/b")
+    }
+
+    @MainActor
+    func test_remove_nonExistent_isNoOp() {
+        store.add(pattern: "/a", filePath: "/tmp/a")
+        store.remove(pattern: "/nonexistent")
+        XCTAssertEqual(store.mappings.count, 1)
+    }
+
+    @MainActor
+    func test_clear_emptiesList() {
+        store.add(pattern: "/a", filePath: "/tmp/a")
+        store.add(pattern: "/b", filePath: "/tmp/b")
+        store.clear()
+        XCTAssertTrue(store.mappings.isEmpty)
+    }
+
+    // MARK: - match
+
+    @MainActor
+    func test_match_regexExact() {
+        store.add(pattern: "^https://api\\.example\\.com/users$", filePath: "/tmp/u.json")
+        XCTAssertEqual(store.match(url: "https://api.example.com/users"), "/tmp/u.json")
+    }
+
+    @MainActor
+    func test_match_regexPartial() {
+        store.add(pattern: ".*\\.analytics\\.com.*", filePath: "/tmp/a.json")
+        XCTAssertEqual(store.match(url: "https://tracker.analytics.com/pixel"), "/tmp/a.json")
+    }
+
+    @MainActor
+    func test_match_firstPatternWins() {
+        store.add(pattern: ".*", filePath: "/tmp/first.json")
+        store.add(pattern: "/api", filePath: "/tmp/second.json")
+        XCTAssertEqual(store.match(url: "/api"), "/tmp/first.json")
+    }
+
+    @MainActor
+    func test_match_noMatchReturnsNil() {
+        store.add(pattern: "^/api$", filePath: "/tmp/x.json")
+        XCTAssertNil(store.match(url: "/other"))
+    }
+
+    @MainActor
+    func test_match_invalidRegexIsIgnored() {
+        // Regex inválido — se saltea silenciosamente.
+        store.add(pattern: "[invalid(", filePath: "/tmp/bad.json")
+        store.add(pattern: "^/good$", filePath: "/tmp/good.json")
+        XCTAssertEqual(store.match(url: "/good"), "/tmp/good.json")
+    }
+
+    // MARK: - persistence
+
+    @MainActor
+    func test_persistence_survivesReload() {
+        store.add(pattern: "/api", filePath: "/tmp/x.json")
+        let reloaded = MapLocalStore(storagePath: storagePath, bus: bus)
+        XCTAssertEqual(reloaded.mappings.count, 1)
+        XCTAssertEqual(reloaded.mappings[0].pattern, "/api")
+        XCTAssertEqual(reloaded.mappings[0].filePath, "/tmp/x.json")
+    }
+
+    @MainActor
+    func test_persistence_clearPersists() {
+        store.add(pattern: "/api", filePath: "/tmp/x.json")
+        store.clear()
+        let reloaded = MapLocalStore(storagePath: storagePath, bus: bus)
+        XCTAssertTrue(reloaded.mappings.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

3a feature migrada. Template del ADR-006 validado: Blocking → StatusOverride → MapLocal sin fricciones.

## Semántica

User define pares (url_regex, local_file). Requests matcheando retornan con el contenido del archivo (200 OK) en vez de ir al server. Content-Type inferido (JSON, JS, HTML, CSS, imágenes). Archivo missing → 404.

**Caso de uso típico**: dev reemplazando assets remotos con versiones locales sin redeployar. Bug reproducido en JSON de API → escribo el JSON arreglado localmente → MapLocal lo devuelve.

## Archivos

### Nuevos
- `Sources/PryApp/Features/MapLocal/MapLocalStore.swift` — @Observable @MainActor, regex on-match, invalidos se skipean
- `Sources/PryApp/Features/MapLocal/MapLocalInterceptor.swift` — phase .resolve, shortCircuit con body del archivo o .notFound
- `Sources/PryApp/Features/MapLocal/MapLocalView.swift` — SwiftUI con NSOpenPanel file picker + 2 PreviewProviders
- `Tests/PryAppTests/Features/MapLocal/MapLocalStoreTests.swift` — 13 tests
- `Tests/PryAppTests/Features/MapLocal/MapLocalInterceptorTests.swift` — 5 tests (incluye tabla de Content-Type para 6 extensiones)

### Modificados
- `Sources/PryLib/Interceptors/Events.swift` — `MapLocalChangedEvent`
- `Sources/PryApp/Core/AppCore.swift` — instancia + registra + preview factory
- `Sources/PryApp/MainWindow.swift` — toolbar item + sheet

### Intacto
- `Sources/PryLib/MapLocal.swift` — legacy, CLI sigue usándolo
- HTTPInterceptor/ConnectHandler — chequeo legacy redundante para PR de higiene

## Verificación

- `swift build` clean
- `swift test` → 304 pass, 0 fail
- `swift test --filter MapLocal` → 24 tests nuevos + legacy tests

## Test plan manual

1. Crear `/tmp/fake-users.json` con `{"users":[{"id":1}]}`
2. Start proxy → Toolbar "Map Local"
3. Agregar pattern `.*/users` + pick `/tmp/fake-users.json`
4. `curl -x http://localhost:8080 http://anything/api/users`
5. Debe responder con el JSON local + Content-Type: application/json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)