### PR TITLE
refactor: skipear chequeos legacy redundantes cuando chain ya ejecutó

### DIFF
--- a/Sources/PryLib/ConnectHandler.swift
+++ b/Sources/PryLib/ConnectHandler.swift
@@ -314,8 +314,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                     // Aplicamos mutaciones del ctx (path + headers) al head. Nota: el
                     // host NO se puede cambiar en HTTPS porque el tunnel TLS ya está
                     // establecido al host original. Cualquier mutación de ctx.host se
-                    // ignora acá (se loguea warning). MapRemote a nivel HTTPS
-                    // requiere intervenir en ConnectHandler ANTES del tunnel.
+                    // ignora acá (se loguea warning).
                     if finalCtx.host != self.host {
                         OutputBroker.shared.log(
                             errText("⚠️  chain tried to change host on established HTTPS tunnel — ignored"),
@@ -323,17 +322,20 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                         )
                     }
                     let mutatedHead = self.applyContextToHead(head, ctx: finalCtx)
-                    self.handleDecryptedRequestLegacy(context: context, head: mutatedHead, body: body)
+                    self.handleDecryptedRequestLegacy(context: context, head: mutatedHead, body: body, chainCovers: true)
                 case .failure:
-                    self.handleDecryptedRequestLegacy(context: context, head: head, body: body)
+                    self.handleDecryptedRequestLegacy(context: context, head: head, body: body, chainCovers: false)
                 }
             }
             return
         }
-        handleDecryptedRequestLegacy(context: context, head: head, body: body)
+        handleDecryptedRequestLegacy(context: context, head: head, body: body, chainCovers: false)
     }
 
-    private func handleDecryptedRequestLegacy(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?) {
+    /// - Parameter chainCovers: si `true`, la chain nueva ya ejecutó HeaderRules /
+    ///   MapRemote / DNSSpoofing (el resto no aplica en HTTPS — gate/resolve ya
+    ///   cortaron antes del tunnel si procedía). Saltearlos acá.
+    private func handleDecryptedRequestLegacy(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?, chainCovers: Bool) {
         let logEntry = "\(head.method) https://\(host)\(head.uri)"
         let requestId = BodyPrinter.printRequestHead(head, host: host, port: port)
         BodyPrinter.printRequestBody(body, requestId: requestId)
@@ -381,7 +383,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
             future.whenSuccess { [self] action in
                 switch action {
                 case .resume:
-                    self.continueRequest(context: context, head: head, body: body, requestId: requestId)
+                    self.continueRequest(context: context, head: head, body: body, requestId: requestId, chainCovers: chainCovers)
                 case .modify(let newHeaders, let newBody):
                     var modifiedHead = head
                     if let headers = newHeaders {
@@ -395,7 +397,7 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
                         buf.writeString(bodyStr)
                         modifiedBody = buf
                     }
-                    self.continueRequest(context: context, head: modifiedHead, body: modifiedBody, requestId: requestId)
+                    self.continueRequest(context: context, head: modifiedHead, body: modifiedBody, requestId: requestId, chainCovers: chainCovers)
                 case .cancel:
                     context.close(promise: nil)
                 }
@@ -403,10 +405,10 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
             return
         }
 
-        continueRequest(context: context, head: head, body: body, requestId: requestId)
+        continueRequest(context: context, head: head, body: body, requestId: requestId, chainCovers: chainCovers)
     }
 
-    private func continueRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?, requestId: Int) {
+    private func continueRequest(context: ChannelHandlerContext, head: HTTPRequestHead, body: ByteBuffer?, requestId: Int, chainCovers: Bool) {
         // Mock check via MockEngine (unified: covers status overrides + mocks)
         if let mock = MockEngine.shared.findMock(path: head.uri, host: host, method: "\(head.method)") {
             let sourceLabel = mock.source?.label ?? "loose"
@@ -493,13 +495,15 @@ final class TLSForwarder: ChannelInboundHandler, @unchecked Sendable {
             forwardingHead.headers.remove(name: "If-Modified-Since")
         }
 
-        // Map Remote + DNS Spoofing
+        // Map Remote + DNS Spoofing — cubiertos por HostRedirect/DNSOverride
+        // interceptors cuando chain corrió. Nota para HTTPS: aunque el tunnel ya
+        // está establecido al host original, mantenemos el legacy path para CLI.
         var connectHost = self.host
-        if let remapped = MapRemote.match(host: self.host) {
+        if !chainCovers, let remapped = MapRemote.match(host: self.host) {
             connectHost = remapped
             OutputBroker.shared.log(info(">>> REDIRECT \(self.host) → \(remapped)"), type: .info)
         }
-        if let spoofedIP = DNSSpoofing.resolve(connectHost) {
+        if !chainCovers, let spoofedIP = DNSSpoofing.resolve(connectHost) {
             connectHost = spoofedIP
         }
 

--- a/Sources/PryLib/HTTPInterceptor.swift
+++ b/Sources/PryLib/HTTPInterceptor.swift
@@ -53,8 +53,9 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
                 case .success((.pass, let finalCtx)):
                     // Chain pasó limpia (posiblemente mutando ctx). Aplicamos las
                     // mutaciones al head + usamos el host/port del ctx final al
-                    // forwardear — esto hace que MapRemote (cambia host),
-                    // HeaderRewrite (cambia headers), etc. afecten el request real.
+                    // forwardear. `chainCovers: true` → skipea los checks que ya
+                    // ejecutó la chain (Block, MapLocal, HeaderRewrite, MapRemote,
+                    // DNSSpoofing).
                     let mutatedHead = self.applyContextToHead(head, ctx: finalCtx)
                     self.handleLegacy(
                         context: context,
@@ -62,24 +63,36 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
                         host: finalCtx.host,
                         port: finalCtx.port,
                         path: finalCtx.path,
-                        body: body
+                        body: body,
+                        chainCovers: true
                     )
                 case .failure:
-                    // Error ejecutando la chain → fallback al flow legacy sin mutaciones.
-                    self.handleLegacy(context: context, head: head, host: host, port: port, path: path, body: body)
+                    // Error ejecutando la chain → fallback al flow legacy completo.
+                    self.handleLegacy(context: context, head: head, host: host, port: port, path: path, body: body, chainCovers: false)
                 }
             }
             return
         }
 
-        // Fallback sin chain (ej. CLI sin inyectar interceptors): flow legacy directo.
-        handleLegacy(context: context, head: head, host: host, port: port, path: path, body: body)
+        // Fallback sin chain (ej. CLI sin inyectar interceptors): flow legacy completo.
+        handleLegacy(context: context, head: head, host: host, port: port, path: path, body: body, chainCovers: false)
     }
 
-    private func handleLegacy(context: ChannelHandlerContext, head: HTTPRequestHead, host: String, port: Int, path: String, body: ByteBuffer?) {
-        // Block list check (legacy — sigue activo para compatibilidad con CLI/TUI
-        // y como safety net mientras se migran features al nuevo patrón).
-        if BlockList.isBlocked(host) {
+    /// - Parameter chainCovers: si `true`, la chain nueva ya ejecutó Block /
+    ///   MapLocal / HeaderRewrite / MapRemote / DNSSpoofing. Saltearlos acá
+    ///   para no duplicar trabajo. Si `false` (CLI o fallback), correrlos
+    ///   como antes.
+    private func handleLegacy(
+        context: ChannelHandlerContext,
+        head: HTTPRequestHead,
+        host: String,
+        port: Int,
+        path: String,
+        body: ByteBuffer?,
+        chainCovers: Bool
+    ) {
+        // Block list check — cubierto por BlockInterceptor cuando chain corrió.
+        if !chainCovers, BlockList.isBlocked(host) {
             OutputBroker.shared.log(errText("🚫 BLOCKED \(host)"), type: .error)
             var headers = HTTPHeaders()
             headers.add(name: "Content-Type", value: "application/json")
@@ -182,17 +195,19 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
             }
         }
 
-        // Map Local check (regex → local file)
-        if let fileContent = MapLocal.matchContent(url: path) {
+        // Map Local check — cubierto por MapLocalInterceptor cuando chain corrió.
+        if !chainCovers, let fileContent = MapLocal.matchContent(url: path) {
             let mapMock = UnifiedMock(pattern: path, body: fileContent, source: .loose)
             respondWithUnifiedMock(context: context, mock: mapMock, path: path, host: host, requestId: requestId)
             return
         }
 
-        // Apply header rewrites before forwarding
+        // Header rewrites — cubierto por HeaderRulesInterceptor cuando chain corrió.
         var rewrittenHead = head
-        let rewrittenHeaders = HeaderRewrite.apply(to: head.headers.map { ($0.name, $0.value) })
-        rewrittenHead.headers = .init(rewrittenHeaders.map { (name: $0.0, value: $0.1) })
+        if !chainCovers {
+            let rewrittenHeaders = HeaderRewrite.apply(to: head.headers.map { ($0.name, $0.value) })
+            rewrittenHead.headers = .init(rewrittenHeaders.map { (name: $0.0, value: $0.1) })
+        }
 
         // Rule Engine: apply scripting rules
         let matchingRules = RuleEngine.matchingRules(for: head.uri, method: "\(head.method)")
@@ -214,15 +229,16 @@ final class HTTPInterceptor: ChannelInboundHandler, RemovableChannelHandler, @un
             rewrittenHead.headers.remove(name: "If-Modified-Since")
         }
 
-        // Map Remote: redirect to different host
+        // Map Remote — cubierto por HostRedirectInterceptor (mutó ctx.host, que ya
+        // se reflejó en `host` cuando chainCovers es true). Solo corre legacy si no.
         var connectHost = host
-        if let remapped = MapRemote.match(host: host) {
+        if !chainCovers, let remapped = MapRemote.match(host: host) {
             connectHost = remapped
             OutputBroker.shared.log(info(">>> REDIRECT \(host) → \(remapped)"), type: .info)
         }
 
-        // DNS Spoofing: override IP resolution
-        if let spoofedIP = DNSSpoofing.resolve(connectHost) {
+        // DNS Spoofing — cubierto por DNSOverrideInterceptor cuando chain corrió.
+        if !chainCovers, let spoofedIP = DNSSpoofing.resolve(connectHost) {
             connectHost = spoofedIP
         }
 


### PR DESCRIPTION
## Summary

Post-Ola 4, las 6 features migradas (Block, StatusOverride, MapLocal, HostRedirects, HeaderRules, DNSOverrides) ejecutan via chain en el pipeline real. Los chequeos legacy en HTTPInterceptor / TLSForwarder que corrían DESPUÉS de la chain quedaron **duplicados** — doble trabajo por request.

## Fix

Parámetro `chainCovers: Bool` en `handleLegacy` y `continueRequest`:

- **GUI (chain inyectada)**: `chainCovers=true` → skipea checks cubiertos por interceptors
- **CLI (sin chain)**: `chainCovers=false` por default → flow legacy completo sin cambios

## Checks que se skipean cuando chain corre

| Check legacy | Cubierto por |
|---|---|
| `BlockList.isBlocked` | `BlockInterceptor` (.gate) |
| `MapLocal.matchContent` | `MapLocalInterceptor` (.resolve) |
| `HeaderRewrite.apply` | `HeaderRulesInterceptor` (.transform) |
| `MapRemote.match` | `HostRedirectInterceptor` (.network) |
| `DNSSpoofing.resolve` | `DNSOverrideInterceptor` (.network) |

## Checks que siguen corriendo (chain no los cubre aún)

- Filter, logging, Recorder hook, Project tracking (observers — no conflict)
- Breakpoints (feature no migrada)
- MockEngine.shared.findMock (feature no migrada — Mock es el gigante siguiente)
- Legacy mock fallback (Config.loadMocks)
- RuleEngine
- No-cache

## Verificación

- `swift build` clean
- `swift test` → **374 pass, 0 fail**
- CLI sigue funcionando igual (sin interceptors → chainCovers=false → path legacy completo)

## Por qué no borrar los chequeos legacy directo

El código legacy sigue sirviendo al CLI/TUI que no inyectan la chain. Borrarlo requeriría migrar el CLI también — scope grande, otro refactor. Esta PR sólo elimina duplicación en el path GUI sin romper CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)